### PR TITLE
0.8 to 0.9 XSL converter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all
-all: well-formed validate export-ol08
+all: well-formed validate convert-09-08
 
 .PHONY: well-formed
 well-formed: examples/*.xml songs/*.xml
@@ -30,8 +30,8 @@ validate: examples/*.xml songs/*.xml
 			fi; \
 		done
 
-.PHONY: export-ol08
-export-ol08: songs/*.xml
+.PHONY: convert-09-08
+convert-09-08: songs/*.xml
 	@mkdir -p export-openlyrics-0.8
 	@rm -f export-openlyrics-0.8/*.xml
 	@echo "Deleting export-openlyrics-0.8/*.xml files"
@@ -61,10 +61,40 @@ export-ol08: songs/*.xml
 				"$$file"; \
 		done
 
+.PHONY: convert-08-09
+convert-08-09: songs/*.xml
+	@echo "Converting schema from 0.8 to 0.9 for song/*.xml files"
+	@for file in songs/*.xml; \
+		do \
+			if grep -q 'version="0.8"' "$$file"; \
+			then \
+				echo -n "Converting schema to OpenLyrics 0.9... $$file\n" && \
+				name=$${file##*/} && \
+				xsltproc \
+					--output songs/"$$name" \
+					tools/openlyrics-0.8-to-openlyrics-0.9.xsl \
+					"$$file"; \
+			fi; \
+		done
+	@for file in songs/*.xml; \
+		do \
+			xmlformat --in-place --config-file=tools/xmlformat.conf "$$file"; \
+			sed --in-place --regexp-extended ':a;N;$$!ba;s/\r{0,1}\n\s+<br\s*\/*>/<br\/>/g' "$$file"; \
+		done
+	@for file in songs/*.xml; \
+		do \
+			echo -n "Validating... " && \
+			xmllint \
+				--noout \
+				--relaxng openlyrics-0.9.rng \
+				"$$file"; \
+		done
+
 .PHONY: help
 help:
 	@echo "Targets:"
-	@echo "  all         - Perform all operations"
-	@echo "  well-formed - Checks that transforming XSL and XML are well formed"
-	@echo "  validate    - Validates OpenLyrics XML files against RelaxNG scheme"
-	@echo "  export-ol08 - Converts OpenLyrics 0.9 files to OpenLyrics 0.8"
+	@echo "  all           - Perform all default operations"
+	@echo "  well-formed   - Checks that transforming XSL and XML are well formed"
+	@echo "  validate      - Validates OpenLyrics XML files against RelaxNG scheme"
+	@echo "  convert-09-08 - Converts OpenLyrics 0.9 files to OpenLyrics 0.8"
+	@echo "  convert-08-09 - Converts OpenLyrics 0.8 files to OpenLyrics 0.9"

--- a/docs/source/chordlist.rst
+++ b/docs/source/chordlist.rst
@@ -62,7 +62,7 @@ Formula                Chord Name                              Shortcode  Notati
 **m3-5-7**             minor major 7th                         minmaj7    mΔ         mMaj7 mM7 -M7 -Δ -Δ7
 **3-a5-7**             augmented major 7th                     augmaj7    +Δ         Maj7(♯5) +Maj7 +M7 +Δ7
 **3-d5-m7**            dominant 7th flat 5                                7,5♭       7(♭5)
-**3-a5-m7**            dominant 7th sharp 5; augmented 7th     aug7       7          7,5♯ 7(♯5)
+**3-a5-m7**            dominant 7th sharp 5; augmented 7th     aug7       +7         7,5♯ 7(♯5)
 **m3-d5-7**            diminished major 7th                               mΔ,5♭      mΔ(5♭) mMaj7(♭5) mM7(♭5) -Δ7(♭5)
 **3-d5-7**             major 7th flat 5                                   Δ,5♭       Δ7(♭5) Maj7(♭5) M7(♭5)
 **3-5-6**              major 6th                               maj6       6          M6 add6
@@ -75,7 +75,7 @@ Formula                Chord Name                              Shortcode  Notati
 **m3-5-m7-9**          minor (dominant)Í 9th                   min9       m9         m7,9 -9 min9
 **m3-5-7-9**           minor major 9th                         minmaj9    mΔ9        mMaj9 mM9 -M9 -Δ9
 **3-a5-7-9**           augmented major 9th                                +Δ9        Maj9(♯5) +Maj9 +M9
-**3-a5-m7-9**          augmented (dominant) 9th                aug9       9          7,9 9,5♯ 9(♯5)
+**3-a5-m7-9**          augmented (dominant) 9th                aug9       +9         +7,9 9,5♯ 9(♯5)
 **m3-d5-m7-9**         half-diminished 9th                     halfdim9   ø9         m9,5♭ m9(♭5) -9(♭5) halfdim9
 **m3-d5-m7-m9**        half-diminished minor 9th                          ø9♭        ø(♭9) m7,9♭,5♭ m7(♭9,♭5) -7(♭9,♭5) halfdim(♭9)
 **m3-d5-d7-9**         diminished 9th                                     °9         dim9
@@ -90,7 +90,7 @@ Formula                Chord Name                              Shortcode  Notati
 **m3-5-m7-9-a11**      acoustic minor (dominant) 11th                     m11♯       m(♯11) -(♯11) min(♯11)
 **m3-5-7-9-a11**       acoustic minor major 11th                          mΔ11♯      mΔ(♯11) mMaj(♯11) mM(♯11) -M(♯11) -Δ(♯11)
 **3-a5-7-9-11**        augmented major 11th                               +Δ11       Maj11(♯5) +Maj11 +M11
-**3-a5-m7-9-11**       augmented (dominant) 11th                          11         11,5♯ 11(♯5)
+**3-a5-m7-9-11**       augmented (dominant) 11th                          +11        11,5♯ 11(♯5)
 **m3-d5-m7-m9-11**     half-diminished 11th                               ø11        m11,5♭ m11(♭5) -11(♭5) halfdim11
 **m3-d5-d7-m9-d11**    diminished 11th                                    °11        dim11
 **3-5-m7-9-11-13**     (dominant) 13th                                    13
@@ -102,7 +102,7 @@ Formula                Chord Name                              Shortcode  Notati
 **m3-5-m7-9-a11-13**   minor (dominant) 13th                              m13(♯11)   -13(♯11) min13(♯11)
 **m3-5-7-9-a11-13**    minor major 13th                                   mΔ13(♯11)  mMaj13(♯11) mM13(♯11) -M13(♯11) -Δ13(♯11)
 **3-a5-7-9-11-13**     augmented major 13th                               +Δ13       Maj13(♯5) +Maj13 +M13
-**3-a5-m7-9-11-13**    augmented (dominant) 13th                          13         13,5♯ 13(♯5)
+**3-a5-m7-9-11-13**    augmented (dominant) 13th                          +13        13,5♯ 13(♯5)
 **m3-d5-m7-m9-11-13**  half-diminished 13th                               ø13        m13,5♭ m13(♭5) -13(♭5) halfdim13
 ====================== ======================================= ========== ========== ===============================================
 
@@ -125,5 +125,5 @@ Formula                Chord Name                              Shortcode  Notati
 **4-5-m7-m9**          dominant minor 9th suspended 4th                   7,9♭,4     7(♭9) 7,9♭,sus4 7(♭9)sus4
 **4-5-7-9**            major 9th suspended 4th                            Δ9,4       Δ9sus4 Maj9,4 M9,4 Maj9sus4 M9sus4
 **4-a5-7-9**           augmented major 9th suspended 4th                  +Δ9,4      +Δ9sus4 Maj9(♯5)4 +M9,4 +M9sus4 +Maj9,4
-**4-a5-m7-9**          augmented (dominant) 9th suspended 4th             9,4        +9sus4 9(♯5)sus4
+**4-a5-m7-9**          augmented (dominant) 9th suspended 4th             +9,4       +9sus4 9(♯5)sus4
 ====================== ======================================= ========== ========== ===============================================

--- a/docs/source/dataformat.rst
+++ b/docs/source/dataformat.rst
@@ -849,7 +849,7 @@ Shortcode    Chord Name                          Notation
 **halfdim7** half-diminished 7th                 ø
 **minmaj7**  minor major 7th                     mΔ
 **augmaj7**  augmented major 7th                 +Δ
-**aug7**     dominant 7th sharp 5; augmented 7th 7
+**aug7**     dominant 7th sharp 5; augmented 7th +7
 **maj6**     major 6th                           6
 **maj6b**    (major minor 6th)                   6♭
 **min6**     minor 6th                           m6
@@ -859,7 +859,7 @@ Shortcode    Chord Name                          Notation
 **maj9**     major 9th                           Δ9
 **min9**     minor (dominant)Í 9th               m9
 **minmaj9**  minor major 9th                     mΔ9
-**aug9**     augmented (dominant) 9th            9
+**aug9**     augmented (dominant) 9th            +9
 **halfdim9** half-diminished 9th                 ø9
 **sus4**     suspended 4th                       4
 **sus2**     suspended 2nd                       2

--- a/openlyrics-0.9.rng
+++ b/openlyrics-0.9.rng
@@ -734,7 +734,7 @@
   </define>
 
   <define name="verseNameType">
-    <data type="ID">
+    <data type="NMTOKEN">
       <param name="minLength">1</param>
       <!-- 3 part: [verse][verse_number][verse_part]
            verse      -    v1, v2, v1a, ...
@@ -747,7 +747,7 @@
   </define>
 
   <define name="instrumentNameType">
-    <data type="ID">
+    <data type="NMTOKEN">
       <param name="minLength">1</param>
       <!-- 3 part: [verse][verse_number][verse_part]
            intro  - i, i1, i2, i1a, ...

--- a/songs/A Mighty Fortress is Our God.xml
+++ b/songs/A Mighty Fortress is Our God.xml
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../stylesheets/openlyrics.css" type="text/css"?>
-<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.8" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:48.233581">
+<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.9" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:48.233581">
   <properties>
     <titles>
       <title>A Mighty Fortress is Our God</title>
@@ -19,38 +19,38 @@
   <lyrics>
     <verse name="v1">
       <lines>
-        <chord name="Bb"/>A mighty <chord name="F"/>fortress <chord name="Eb"/>is our <chord name="Bb"/>God, a <chord name="Gm"/>Bulwark <chord name="Bb"/>never <chord name="Eb"/>fa<chord name="F"/>i<chord name="Bb"/>ling;<br/>
-        <chord name="Bb"/>Our Helper <chord name="F"/>He a<chord name="Eb"/>mid the <chord name="Bb"/>flood of <chord name="Gm"/>mortal <chord name="Bb"/>ills pre<chord name="Eb"/>va<chord name="F"/>i<chord name="Bb"/>ling;<br/>
-        For <chord name="Gm"/>still our <chord name="Csus"/>an<chord name="C"/>cient <chord name="F"/>Foe doth <chord name="Bb"/>seek to <chord name="Eb"/>work us <chord name="Gm"/>woe;<br/>
-        His <chord name="Gm"/>craft and <chord name="Csus"/>pow'r <chord name="C"/>are <chord name="F"/>great, and <chord name="Gm"/>armed with <chord name="Cm"/>cruel <chord name="D"/>hate,<br/>
-        On <chord name="Gm"/>earth is <chord name="Bb"/>not his <chord name="Eb"/>e<chord name="F"/><chord name="Bb"/>qual.
+        <chord root="Bb"/>A mighty <chord root="F"/>fortress <chord root="Eb"/>is our <chord root="Bb"/>God, a <chord root="G" structure="min"/>Bulwark <chord root="Bb"/>never <chord root="Eb"/>fa<chord root="F"/>i<chord root="Bb"/>ling;<br/>
+        <chord root="Bb"/>Our Helper <chord root="F"/>He a<chord root="Eb"/>mid the <chord root="Bb"/>flood of <chord root="G" structure="min"/>mortal <chord root="Bb"/>ills pre<chord root="Eb"/>va<chord root="F"/>i<chord root="Bb"/>ling;<br/>
+        For <chord root="G" structure="min"/>still our <chord root="C" structure="sus4"/>an<chord root="C"/>cient <chord root="F"/>Foe doth <chord root="Bb"/>seek to <chord root="Eb"/>work us <chord root="G" structure="min"/>woe;<br/>
+        His <chord root="G" structure="min"/>craft and <chord root="C" structure="sus4"/>pow'r <chord root="C"/>are <chord root="F"/>great, and <chord root="G" structure="min"/>armed with <chord root="C" structure="min"/>cruel <chord root="D"/>hate,<br/>
+        On <chord root="G" structure="min"/>earth is <chord root="Bb"/>not his <chord root="Eb"/>e<chord root="F"/><chord root="Bb"/>qual.
       </lines>
     </verse>
     <verse name="v2">
       <lines>
-        <chord name="Bb"/>Did we in <chord name="F"/>our own <chord name="Eb"/>strength con<chord name="Bb"/>fide, our <chord name="Gm"/>striving <chord name="Bb"/>would be <chord name="Eb"/>lo<chord name="F"/><chord name="Bb"/>sing;<br/>
-        <chord name="Bb"/>Were not the <chord name="F"/>right Man <chord name="Eb"/>on our <chord name="Bb"/>side, the <chord name="Gm"/>Man of <chord name="Bb"/>God's own <chord name="Eb"/>cho<chord name="F"/>o<chord name="Bb"/>sing;<br/>
-        Dost<chord name="Gm"/> ask who <chord name="Csus"/>that <chord name="C"/>may <chord name="F"/>be: Christ <chord name="Bb"/>Jesus <chord name="Eb"/>it is <chord name="Gm"/>He;<br/>
-        Lord <chord name="Gm"/>Sabba<chord name="Csus"/>oth  <chord name="C"/>His <chord name="F"/>name, from  <chord name="Gm"/>age to <chord name="Cm"/>age the <chord name="D"/>same,<br/>
-        And <chord name="Gm"/>He must <chord name="Bb"/>win the <chord name="Eb"/>bat<chord name="F"/><chord name="Bb"/>tle.
+        <chord root="Bb"/>Did we in <chord root="F"/>our own <chord root="Eb"/>strength con<chord root="Bb"/>fide, our <chord root="G" structure="min"/>striving <chord root="Bb"/>would be <chord root="Eb"/>lo<chord root="F"/><chord root="Bb"/>sing;<br/>
+        <chord root="Bb"/>Were not the <chord root="F"/>right Man <chord root="Eb"/>on our <chord root="Bb"/>side, the <chord root="G" structure="min"/>Man of <chord root="Bb"/>God's own <chord root="Eb"/>cho<chord root="F"/>o<chord root="Bb"/>sing;<br/>
+        Dost<chord root="G" structure="min"/> ask who <chord root="C" structure="sus4"/>that <chord root="C"/>may <chord root="F"/>be: Christ <chord root="Bb"/>Jesus <chord root="Eb"/>it is <chord root="G" structure="min"/>He;<br/>
+        Lord <chord root="G" structure="min"/>Sabba<chord root="C" structure="sus4"/>oth <chord root="C"/>His <chord root="F"/>name, from <chord root="G" structure="min"/>age to <chord root="C" structure="min"/>age the <chord root="D"/>same,<br/>
+        And <chord root="G" structure="min"/>He must <chord root="Bb"/>win the <chord root="Eb"/>bat<chord root="F"/><chord root="Bb"/>tle.
       </lines>
     </verse>
     <verse name="v3">
       <lines>
-        <chord name="Bb"/>And though this <chord name="F"/>world with <chord name="Eb"/>devils <chord name="Bb"/>filled should <chord name="Gm"/>threaten <chord name="Bb"/>to un<chord name="Eb"/>do <chord name="F"/>  <chord name="Bb"/>us;<br/>
-        <chord name="Bb"/>We will not <chord name="F"/>fear for <chord name="Eb"/>God hath <chord name="Bb"/>willed His <chord name="Gm"/>truth to <chord name="Bb"/>triumph <chord name="Eb"/>thr<chord name="F"/>ough <chord name="Bb"/>us:<br/>
-        The <chord name="Gm"/>prince of <chord name="Csus"/>dark<chord name="C"/>ness <chord name="F"/>grim, we <chord name="Bb"/>tremble <chord name="Eb"/>not for <chord name="Gm"/>him;<br/>
-        His <chord name="Gm"/>rage we <chord name="Csus"/>can  <chord name="C"/>en<chord name="F"/>dure for <chord name="Gm"/>lo, his <chord name="Cm"/>doom is <chord name="D"/>sure,<br/>
-        One <chord name="Gm"/>little <chord name="Bb"/>word shall <chord name="Eb"/>fel<chord name="F"/>l <chord name="Bb"/>him.
+        <chord root="Bb"/>And though this <chord root="F"/>world with <chord root="Eb"/>devils <chord root="Bb"/>filled should <chord root="G" structure="min"/>threaten <chord root="Bb"/>to un<chord root="Eb"/>do <chord root="F"/> <chord root="Bb"/>us;<br/>
+        <chord root="Bb"/>We will not <chord root="F"/>fear for <chord root="Eb"/>God hath <chord root="Bb"/>willed His <chord root="G" structure="min"/>truth to <chord root="Bb"/>triumph <chord root="Eb"/>thr<chord root="F"/>ough <chord root="Bb"/>us:<br/>
+        The <chord root="G" structure="min"/>prince of <chord root="C" structure="sus4"/>dark<chord root="C"/>ness <chord root="F"/>grim, we <chord root="Bb"/>tremble <chord root="Eb"/>not for <chord root="G" structure="min"/>him;<br/>
+        His <chord root="G" structure="min"/>rage we <chord root="C" structure="sus4"/>can <chord root="C"/>en<chord root="F"/>dure for <chord root="G" structure="min"/>lo, his <chord root="C" structure="min"/>doom is <chord root="D"/>sure,<br/>
+        One <chord root="G" structure="min"/>little <chord root="Bb"/>word shall <chord root="Eb"/>fel<chord root="F"/>l <chord root="Bb"/>him.
       </lines>
     </verse>
     <verse name="v4">
       <lines>
-        <chord name="Bb"/>That Word a<chord name="F"/>bove all <chord name="Eb"/>earthly <chord name="Bb"/>pow'r, no <chord name="Gm"/>thanks to <chord name="Bb"/>them a<chord name="Eb"/>bid<chord name="F"/><chord name="Bb"/>eth;<br/>
-        <chord name="Bb"/>The Spirit <chord name="F"/>and the <chord name="Eb"/>gifts are <chord name="Bb"/>ours through <chord name="Gm"/>Him who <chord name="Bb"/>with us <chord name="Eb"/>si<chord name="F"/><chord name="Bb"/>deth;<br/>
-        Let <chord name="Gm"/>goods and <chord name="Csus"/>kin<chord name="C"/>dred  <chord name="F"/>go, this <chord name="Bb"/>mortal <chord name="Eb"/>life al<chord name="Gm"/>so;<br/>
-        The <chord name="Gm"/>body <chord name="Csus"/>they  <chord name="C"/>may <chord name="F"/>kill; God's <chord name="Gm"/>truth a<chord name="Cm"/>bideth <chord name="D"/>still,<br/>
-        His <chord name="Gm"/>kingdom <chord name="Bb"/>is for<chord name="Eb"/>e<chord name="F"/><chord name="Bb"/>ver!
+        <chord root="Bb"/>That Word a<chord root="F"/>bove all <chord root="Eb"/>earthly <chord root="Bb"/>pow'r, no <chord root="G" structure="min"/>thanks to <chord root="Bb"/>them a<chord root="Eb"/>bid<chord root="F"/><chord root="Bb"/>eth;<br/>
+        <chord root="Bb"/>The Spirit <chord root="F"/>and the <chord root="Eb"/>gifts are <chord root="Bb"/>ours through <chord root="G" structure="min"/>Him who <chord root="Bb"/>with us <chord root="Eb"/>si<chord root="F"/><chord root="Bb"/>deth;<br/>
+        Let <chord root="G" structure="min"/>goods and <chord root="C" structure="sus4"/>kin<chord root="C"/>dred <chord root="F"/>go, this <chord root="Bb"/>mortal <chord root="Eb"/>life al<chord root="G" structure="min"/>so;<br/>
+        The <chord root="G" structure="min"/>body <chord root="C" structure="sus4"/>they <chord root="C"/>may <chord root="F"/>kill; God's <chord root="G" structure="min"/>truth a<chord root="C" structure="min"/>bideth <chord root="D"/>still,<br/>
+        His <chord root="G" structure="min"/>kingdom <chord root="Bb"/>is for<chord root="Eb"/>e<chord root="F"/><chord root="Bb"/>ver!
       </lines>
     </verse>
   </lyrics>

--- a/songs/All Hail The Power Of Jesus Name.xml
+++ b/songs/All Hail The Power Of Jesus Name.xml
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../stylesheets/openlyrics.css" type="text/css"?>
-<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.8" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:47.974846">
+<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.9" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:47.974846">
   <properties>
     <titles>
       <title>All Hail The Power Of Jesus' Name</title>
@@ -20,30 +20,30 @@
   <lyrics>
     <verse name="v1">
       <lines>
-        All <chord name="D/F#"/>hail the pow’r of <chord name="A"/>Jesus’ name! Let angels <chord name="D/A"/>pros<chord name="A"/>trate <chord name="D"/>fall;<br/>
-        <chord name="A"/>Bring <chord name="D"/>forth the <chord name="D/F#"/>royal <chord name="A"/>dia<chord name="D"/>dem, And crown <chord name="A/C#"/>Him  <chord name="Bm"/>Lord <chord name="A/E"/>of<chord name="E"/>  <chord name="A"/>all.<br/>
-        Bring <chord name="D"/>forth the <chord name="D/F#"/>royal <chord name="A"/>diadem, And <chord name="D/F#"/>crown <chord name="G"/>Him <chord name="D/F#"/>Lord<chord name="A"/> of <chord name="D"/>all.
+        All <chord root="D" bass="F#"/>hail the pow’r of <chord root="A"/>Jesus’ name! Let angels <chord root="D" bass="A"/>pros<chord root="A"/>trate <chord root="D"/>fall;<br/>
+        <chord root="A"/>Bring <chord root="D"/>forth the <chord root="D" bass="F#"/>royal <chord root="A"/>dia<chord root="D"/>dem, And crown <chord root="A" bass="C#"/>Him <chord root="B" structure="min"/>Lord <chord root="A" bass="E"/>of<chord root="E"/> <chord root="A"/>all.<br/>
+        Bring <chord root="D"/>forth the <chord root="D" bass="F#"/>royal <chord root="A"/>diadem, And <chord root="D" bass="F#"/>crown <chord root="G"/>Him <chord root="D" bass="F#"/>Lord<chord root="A"/> of <chord root="D"/>all.
       </lines>
     </verse>
     <verse name="v2">
       <lines>
-        Ye  <chord name="D/F#"/>chosen seed of  <chord name="A"/>Israel’s race, Ye  ransomed <chord name="D/A"/>from <chord name="A"/>the <chord name="D"/>fall,<br/>
-        <chord name="A"/>Hail <chord name="D"/>Him Who <chord name="D/F#"/>saves you <chord name="A"/>by His <chord name="D"/>grace, And crown <chord name="A/C#"/>Him  <chord name="Bm"/>Lord <chord name="A/E"/>of<chord name="E"/>  <chord name="A"/>all.<br/>
-        Hail <chord name="D"/>Him Who <chord name="D/F#"/>saves you <chord name="A"/>by His grace, And <chord name="D/F#"/>crown <chord name="G"/>Him <chord name="D/F#"/>Lord<chord name="A"/> of <chord name="D"/>all.
+        Ye <chord root="D" bass="F#"/>chosen seed of <chord root="A"/>Israel’s race, Ye ransomed <chord root="D" bass="A"/>from <chord root="A"/>the <chord root="D"/>fall,<br/>
+        <chord root="A"/>Hail <chord root="D"/>Him Who <chord root="D" bass="F#"/>saves you <chord root="A"/>by His <chord root="D"/>grace, And crown <chord root="A" bass="C#"/>Him <chord root="B" structure="min"/>Lord <chord root="A" bass="E"/>of<chord root="E"/> <chord root="A"/>all.<br/>
+        Hail <chord root="D"/>Him Who <chord root="D" bass="F#"/>saves you <chord root="A"/>by His grace, And <chord root="D" bass="F#"/>crown <chord root="G"/>Him <chord root="D" bass="F#"/>Lord<chord root="A"/> of <chord root="D"/>all.
       </lines>
     </verse>
     <verse name="v3">
       <lines>
-        Let <chord name="E/G#"/>every kindred, <chord name="B"/>every tribe On this ter<chord name="E/B"/>res<chord name="B"/>trial <chord name="E"/>ball<br/>
-        <chord name="B"/>To <chord name="E"/>Him all <chord name="E/G#"/>majes<chord name="B"/>ty a<chord name="E"/>scribe, And crown <chord name="B/D#"/>Him  <chord name="C#m"/>Lord <chord name="B/F#"/>of<chord name="F#"/>   <chord name="B"/>all.<br/>
-        To <chord name="E"/>Him all <chord name="E/G#"/>majes<chord name="B"/>ty ascribe, And <chord name="E/G#"/>crown <chord name="A"/>Him <chord name="E/G#"/>Lord<chord name="B"/> of <chord name="E"/>all.
+        Let <chord root="E" bass="G#"/>every kindred, <chord root="B"/>every tribe On this ter<chord root="E" bass="B"/>res<chord root="B"/>trial <chord root="E"/>ball<br/>
+        <chord root="B"/>To <chord root="E"/>Him all <chord root="E" bass="G#"/>majes<chord root="B"/>ty a<chord root="E"/>scribe, And crown <chord root="B" bass="D#"/>Him <chord root="C#" structure="min"/>Lord <chord root="B" bass="F#"/>of<chord root="F#"/> <chord root="B"/>all.<br/>
+        To <chord root="E"/>Him all <chord root="E" bass="G#"/>majes<chord root="B"/>ty ascribe, And <chord root="E" bass="G#"/>crown <chord root="A"/>Him <chord root="E" bass="G#"/>Lord<chord root="B"/> of <chord root="E"/>all.
       </lines>
     </verse>
     <verse name="v4">
       <lines>
-        O <chord name="E/G#"/>that with yonder <chord name="B"/>sacred throng We at His <chord name="E/B"/>feet <chord name="B"/>may  <chord name="E"/>fall<br/>
-        <chord name="B"/>We’ll <chord name="E"/>join the <chord name="E/G#"/>ever<chord name="B"/>last<chord name="E"/>ing song, And crown <chord name="B/D#"/>Him  <chord name="C#m"/>Lord <chord name="B/F#"/>of<chord name="F#"/>   <chord name="B"/>all.<br/>
-        We’ll <chord name="E"/>join the <chord name="E/G#"/>ever<chord name="B"/>lasting song, And <chord name="E/G#"/>crown <chord name="A"/>Him <chord name="E/G#"/>Lord<chord name="B"/> of <chord name="E"/>all.
+        O <chord root="E" bass="G#"/>that with yonder <chord root="B"/>sacred throng We at His <chord root="E" bass="B"/>feet <chord root="B"/>may <chord root="E"/>fall<br/>
+        <chord root="B"/>We’ll <chord root="E"/>join the <chord root="E" bass="G#"/>ever<chord root="B"/>last<chord root="E"/>ing song, And crown <chord root="B" bass="D#"/>Him <chord root="C#" structure="min"/>Lord <chord root="B" bass="F#"/>of<chord root="F#"/> <chord root="B"/>all.<br/>
+        We’ll <chord root="E"/>join the <chord root="E" bass="G#"/>ever<chord root="B"/>lasting song, And <chord root="E" bass="G#"/>crown <chord root="A"/>Him <chord root="E" bass="G#"/>Lord<chord root="B"/> of <chord root="E"/>all.
       </lines>
     </verse>
   </lyrics>

--- a/songs/Amazing Grace.xml
+++ b/songs/Amazing Grace.xml
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../stylesheets/openlyrics.css" type="text/css"?>
-<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.8" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:48.137828">
+<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.9" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:48.137828">
   <properties>
     <titles>
       <title>Amazing Grace</title>
@@ -17,26 +17,26 @@
   <lyrics>
     <verse name="v1">
       <lines>
-        A<chord name="D"/>mazing <chord name="D7"/>grace how <chord name="G"/>sweet the <chord name="D"/>sound that <chord name="Bm"/>saved a <chord name="E"/>wretch like <chord name="A"/>me;<br/>
-        I <chord name="D"/>once was <chord name="D7"/>lost but <chord name="G"/>now I'm <chord name="D"/>found, was <chord name="Bm"/>blind but <chord name="A"/>now I <chord name="G"/>see.
+        A<chord root="D"/>mazing <chord root="D" structure="dom7"/>grace how <chord root="G"/>sweet the <chord root="D"/>sound that <chord root="B" structure="min"/>saved a <chord root="E"/>wretch like <chord root="A"/>me;<br/>
+        I <chord root="D"/>once was <chord root="D" structure="dom7"/>lost but <chord root="G"/>now I'm <chord root="D"/>found, was <chord root="B" structure="min"/>blind but <chord root="A"/>now I <chord root="G"/>see.
       </lines>
     </verse>
     <verse name="v2">
       <lines>
-        Twas <chord name="D"/>grace that <chord name="D7"/>taught my <chord name="G"/>heart to <chord name="D"/>fear, and <chord name="Bm"/>grace my <chord name="E"/>fears re<chord name="A"/>lieved;<br/>
-        How <chord name="D"/>precious <chord name="D7"/>did that <chord name="G"/>grace ap<chord name="D"/>pear the <chord name="Bm"/>hour I <chord name="A"/>first be<chord name="G"/>lieved!
+        Twas <chord root="D"/>grace that <chord root="D" structure="dom7"/>taught my <chord root="G"/>heart to <chord root="D"/>fear, and <chord root="B" structure="min"/>grace my <chord root="E"/>fears re<chord root="A"/>lieved;<br/>
+        How <chord root="D"/>precious <chord root="D" structure="dom7"/>did that <chord root="G"/>grace ap<chord root="D"/>pear the <chord root="B" structure="min"/>hour I <chord root="A"/>first be<chord root="G"/>lieved!
       </lines>
     </verse>
     <verse name="v3">
       <lines>
-        Through <chord name="D"/>many <chord name="D7"/>dangers, <chord name="G"/>toils, and <chord name="D"/>snares I <chord name="Bm"/>have al<chord name="E"/>ready <chord name="A"/>come;<br/>
-        'Tis <chord name="D"/>grace that <chord name="D7"/>brought me <chord name="G"/>safe thus <chord name="D"/>far and <chord name="Bm"/>grace will <chord name="A"/>lead me <chord name="G"/>home.
+        Through <chord root="D"/>many <chord root="D" structure="dom7"/>dangers, <chord root="G"/>toils, and <chord root="D"/>snares I <chord root="B" structure="min"/>have al<chord root="E"/>ready <chord root="A"/>come;<br/>
+        'Tis <chord root="D"/>grace that <chord root="D" structure="dom7"/>brought me <chord root="G"/>safe thus <chord root="D"/>far and <chord root="B" structure="min"/>grace will <chord root="A"/>lead me <chord root="G"/>home.
       </lines>
     </verse>
     <verse name="v4">
       <lines>
-        When <chord name="D"/>we've been <chord name="D7"/>there ten <chord name="G"/>thousand <chord name="D"/>years bright <chord name="Bm"/>shining <chord name="E"/>as the <chord name="A"/>sun;<br/>
-        We've <chord name="D"/>no less <chord name="D7"/>days to <chord name="G"/>sing God's <chord name="D"/>praise than <chord name="Bm"/>when we'd <chord name="A"/>first be<chord name="G"/>gun!
+        When <chord root="D"/>we've been <chord root="D" structure="dom7"/>there ten <chord root="G"/>thousand <chord root="D"/>years bright <chord root="B" structure="min"/>shining <chord root="E"/>as the <chord root="A"/>sun;<br/>
+        We've <chord root="D"/>no less <chord root="D" structure="dom7"/>days to <chord root="G"/>sing God's <chord root="D"/>praise than <chord root="B" structure="min"/>when we'd <chord root="A"/>first be<chord root="G"/>gun!
       </lines>
     </verse>
   </lyrics>

--- a/songs/And Can It Be.xml
+++ b/songs/And Can It Be.xml
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../stylesheets/openlyrics.css" type="text/css"?>
-<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.8" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:48.322812">
+<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.9" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:48.322812">
   <properties>
     <titles>
       <title>And Can It Be</title>
@@ -18,38 +18,38 @@
   <lyrics>
     <verse name="v1">
       <lines>
-        <chord name="G"/>And can be that <chord name="Am/C"/>I <chord name="D"/>should <chord name="G"/>gain,<br/>
-        an <chord name="C"/>in<chord name="D"/>terest <chord name="G"/>in my <chord name="D"/>Sa<chord name="A"/>vior's <chord name="D"/>blood?<br/>
-        <chord name="D"/>Died He for <chord name="G/D"/>me, who <chord name="G/B"/>caused His <chord name="D"/>pain?<br/>
-        For <chord name="C"/>me, who <chord name="G"/>Him to <chord name="D"/>death pur<chord name="G"/>sued?<br/>
-        <chord name="G"/>Amazing <chord name="G/D"/>love, how <chord name="C"/>can <chord name="A"/>it <chord name="D"/>be<br/>
-        That <chord name="G"/>thou my <chord name="C"/>Lord should <chord name="D"/>die for <chord name="G"/>me?
+        <chord root="G"/>And can be that <chord root="A" structure="min" bass="C"/>I <chord root="D"/>should <chord root="G"/>gain,<br/>
+        an <chord root="C"/>in<chord root="D"/>terest <chord root="G"/>in my <chord root="D"/>Sa<chord root="A"/>vior's <chord root="D"/>blood?<br/>
+        <chord root="D"/>Died He for <chord root="G" bass="D"/>me, who <chord root="G" bass="B"/>caused His <chord root="D"/>pain?<br/>
+        For <chord root="C"/>me, who <chord root="G"/>Him to <chord root="D"/>death pur<chord root="G"/>sued?<br/>
+        <chord root="G"/>Amazing <chord root="G" bass="D"/>love, how <chord root="C"/>can <chord root="A"/>it <chord root="D"/>be<br/>
+        That <chord root="G"/>thou my <chord root="C"/>Lord should <chord root="D"/>die for <chord root="G"/>me?
       </lines>
     </verse>
     <verse name="c">
       <lines>
-        A<chord name="G"/>mazing <chord name="D"/>love, how <chord name="C"/>can it <chord name="G"/>be<br/>
-        That <chord name="C"/>thou my <chord name="G"/>God <chord name="Am"/>should <chord name="C"/>die <chord name="D"/>for <chord name="G"/>me?
+        A<chord root="G"/>mazing <chord root="D"/>love, how <chord root="C"/>can it <chord root="G"/>be<br/>
+        That <chord root="C"/>thou my <chord root="G"/>God <chord root="A" structure="min"/>should <chord root="C"/>die <chord root="D"/>for <chord root="G"/>me?
       </lines>
     </verse>
     <verse name="v2">
       <lines>
-        <chord name="G"/>Long my imprisoned <chord name="Am/C"/>spi<chord name="D"/>rit <chord name="G"/>lay,<br/>
-        Fast <chord name="C"/>bound <chord name="D"/>in <chord name="G"/>sin and <chord name="D"/>na<chord name="A"/>ture's <chord name="D"/>night,<br/>
-        <chord name="D"/>Thine eye dif<chord name="G/D"/>fused a <chord name="G/B"/>quickening <chord name="D"/>ray,<br/>
-        I <chord name="C"/>woke, the <chord name="G"/>dungeon <chord name="D"/>flamed with <chord name="G"/>light;<br/>
-        <chord name="G"/>My chains fell <chord name="G/D"/>off, my <chord name="C"/>heart <chord name="A"/>was <chord name="D"/>free,<br/>
-        I <chord name="G"/>rose, went <chord name="C"/>forth and <chord name="D"/>followed <chord name="G"/>thee.
+        <chord root="G"/>Long my imprisoned <chord root="A" structure="min" bass="C"/>spi<chord root="D"/>rit <chord root="G"/>lay,<br/>
+        Fast <chord root="C"/>bound <chord root="D"/>in <chord root="G"/>sin and <chord root="D"/>na<chord root="A"/>ture's <chord root="D"/>night,<br/>
+        <chord root="D"/>Thine eye dif<chord root="G" bass="D"/>fused a <chord root="G" bass="B"/>quickening <chord root="D"/>ray,<br/>
+        I <chord root="C"/>woke, the <chord root="G"/>dungeon <chord root="D"/>flamed with <chord root="G"/>light;<br/>
+        <chord root="G"/>My chains fell <chord root="G" bass="D"/>off, my <chord root="C"/>heart <chord root="A"/>was <chord root="D"/>free,<br/>
+        I <chord root="G"/>rose, went <chord root="C"/>forth and <chord root="D"/>followed <chord root="G"/>thee.
       </lines>
     </verse>
     <verse name="v3">
       <lines>
-        <chord name="G"/>No condemnation <chord name="Am/C"/>now <chord name="D"/>I <chord name="G"/>dread,<br/>
-        Je<chord name="C"/>sus, <chord name="D"/>and <chord name="G"/>all in <chord name="D"/>Him, <chord name="A"/>is <chord name="D"/>mine;<br/>
-        <chord name="D"/>Alive in <chord name="G/D"/>Him, my <chord name="G/B"/>living <chord name="D"/>Head<br/>
-        and <chord name="C"/>clothed with <chord name="G"/>righteous<chord name="D"/>ness di<chord name="G"/>vine,<br/>
-        <chord name="G"/>Bold I ap<chord name="G/D"/>proach the e<chord name="C"/>ter<chord name="A"/>nal <chord name="D"/>throne,<br/>
-        And <chord name="G"/>claim the <chord name="C"/>crown through <chord name="D"/>Christ, my <chord name="G"/>own.
+        <chord root="G"/>No condemnation <chord root="A" structure="min" bass="C"/>now <chord root="D"/>I <chord root="G"/>dread,<br/>
+        Je<chord root="C"/>sus, <chord root="D"/>and <chord root="G"/>all in <chord root="D"/>Him, <chord root="A"/>is <chord root="D"/>mine;<br/>
+        <chord root="D"/>Alive in <chord root="G" bass="D"/>Him, my <chord root="G" bass="B"/>living <chord root="D"/>Head<br/>
+        and <chord root="C"/>clothed with <chord root="G"/>righteous<chord root="D"/>ness di<chord root="G"/>vine,<br/>
+        <chord root="G"/>Bold I ap<chord root="G" bass="D"/>proach the e<chord root="C"/>ter<chord root="A"/>nal <chord root="D"/>throne,<br/>
+        And <chord root="G"/>claim the <chord root="C"/>crown through <chord root="D"/>Christ, my <chord root="G"/>own.
       </lines>
     </verse>
   </lyrics>

--- a/songs/Are You Washed.xml
+++ b/songs/Are You Washed.xml
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../stylesheets/openlyrics.css" type="text/css"?>
-<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.8" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:48.411382">
+<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.9" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:48.411382">
   <properties>
     <titles>
       <title>Are You Washed</title>
@@ -17,42 +17,42 @@
   <lyrics>
     <verse name="v1">
       <lines>
-        Have you <chord name="D"/>been to Jesus for the <chord name="G"/>cleansing <chord name="D"/>power?<br/>
-        Are you washed in the blood of the <chord name="A7"/>Lamb?<br/>
-        Are you <chord name="D"/>fully trusting in His <chord name="G"/>grace this hour?<br/>
-        Are you <chord name="D"/>washed in the <chord name="A7"/>blood of the <chord name="D"/>Lamb?
+        Have you <chord root="D"/>been to Jesus for the <chord root="G"/>cleansing <chord root="D"/>power?<br/>
+        Are you washed in the blood of the <chord root="A" structure="dom7"/>Lamb?<br/>
+        Are you <chord root="D"/>fully trusting in His <chord root="G"/>grace this hour?<br/>
+        Are you <chord root="D"/>washed in the <chord root="A" structure="dom7"/>blood of the <chord root="D"/>Lamb?
       </lines>
     </verse>
     <verse name="v2">
       <lines>
-        Are you <chord name="D"/>walking daily by the <chord name="G"/>Savior’s <chord name="D"/>side?<br/>
-        Are you washed in the blood of the <chord name="A7"/>Lamb?<br/>
-        Do you <chord name="D"/>rest each moment in the <chord name="G"/>Crucified?<br/>
-        Are you <chord name="D"/>washed in the <chord name="A7"/>blood of the <chord name="D"/>Lamb?
+        Are you <chord root="D"/>walking daily by the <chord root="G"/>Savior’s <chord root="D"/>side?<br/>
+        Are you washed in the blood of the <chord root="A" structure="dom7"/>Lamb?<br/>
+        Do you <chord root="D"/>rest each moment in the <chord root="G"/>Crucified?<br/>
+        Are you <chord root="D"/>washed in the <chord root="A" structure="dom7"/>blood of the <chord root="D"/>Lamb?
       </lines>
     </verse>
     <verse name="v3">
       <lines>
-        When the <chord name="D"/>Bridegroom cometh, will your <chord name="G"/>robes be <chord name="D"/>white?<br/>
-        Pure and white in the blood of the <chord name="A7"/>Lamb?<br/>
-        Will your <chord name="D"/>souls be ready for the <chord name="G"/>mansions bright,<br/>
-        And be <chord name="D"/>washed in the <chord name="A7"/>blood of the <chord name="D"/>Lamb?
+        When the <chord root="D"/>Bridegroom cometh, will your <chord root="G"/>robes be <chord root="D"/>white?<br/>
+        Pure and white in the blood of the <chord root="A" structure="dom7"/>Lamb?<br/>
+        Will your <chord root="D"/>souls be ready for the <chord root="G"/>mansions bright,<br/>
+        And be <chord root="D"/>washed in the <chord root="A" structure="dom7"/>blood of the <chord root="D"/>Lamb?
       </lines>
     </verse>
     <verse name="v4">
       <lines>
-        Lay a<chord name="D"/>side your garments that are <chord name="G"/>stained with <chord name="D"/>sin<br/>
-        And be washed in the blood of the <chord name="A7"/>Lamb.<br/>
-        There’s a <chord name="D"/>fountain flowing for the <chord name="G"/>soul unclean.<br/>
-        O, be <chord name="D"/>washed in the <chord name="A7"/>blood of the <chord name="D"/>Lamb?
+        Lay a<chord root="D"/>side your garments that are <chord root="G"/>stained with <chord root="D"/>sin<br/>
+        And be washed in the blood of the <chord root="A" structure="dom7"/>Lamb.<br/>
+        There’s a <chord root="D"/>fountain flowing for the <chord root="G"/>soul unclean.<br/>
+        O, be <chord root="D"/>washed in the <chord root="A" structure="dom7"/>blood of the <chord root="D"/>Lamb?
       </lines>
     </verse>
     <verse name="c">
       <lines>
-        Are you <chord name="D"/>washed in the <chord name="G"/>blood,<br/>
-        In the <chord name="D"/>soul-cleansing blood of the <chord name="A7"/>Lamb?<br/>
-        Are your <chord name="D"/>garments spotless are they <chord name="G"/>white as snow?<br/>
-        Are you <chord name="D"/>washed in the <chord name="A7"/>blood of the <chord name="D"/>Lamb?
+        Are you <chord root="D"/>washed in the <chord root="G"/>blood,<br/>
+        In the <chord root="D"/>soul-cleansing blood of the <chord root="A" structure="dom7"/>Lamb?<br/>
+        Are your <chord root="D"/>garments spotless are they <chord root="G"/>white as snow?<br/>
+        Are you <chord root="D"/>washed in the <chord root="A" structure="dom7"/>blood of the <chord root="D"/>Lamb?
       </lines>
     </verse>
   </lyrics>

--- a/songs/Be Thou My Vision.xml
+++ b/songs/Be Thou My Vision.xml
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../stylesheets/openlyrics.css" type="text/css"?>
-<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.8" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:48.499155">
+<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.9" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:48.499155">
   <properties>
     <titles>
       <title>Be Thou My Vision</title>
@@ -19,34 +19,34 @@
   <lyrics>
     <verse name="v1">
       <lines>
-        <chord name="D"/>Be Thou my <chord name="Bm7"/>Vision, O <chord name="G"/>Lord of my <chord name="D"/>heart,<br/>
-        <chord name="A"/>Naught be all <chord name="Bm7"/>else to me <chord name="G"/>save that Thou <chord name="A"/>art;<br/>
-        <chord name="Gmaj7"/>Thou my best <chord name="F#m7"/>thought by <chord name="D"/>day or by <chord name="G"/>night<chord name="A"/>,<br/>
-        <chord name="D"/>Waking or <chord name="Bm7"/>sleeping, Thy <chord name="G2"/>presence my <chord name="D"/>light.
+        <chord root="D"/>Be Thou my <chord root="B" structure="min7"/>Vision, O <chord root="G"/>Lord of my <chord root="D"/>heart,<br/>
+        <chord root="A"/>Naught be all <chord root="B" structure="min7"/>else to me <chord root="G"/>save that Thou <chord root="A"/>art;<br/>
+        <chord root="G" structure="maj7"/>Thou my best <chord root="F#" structure="min7"/>thought by <chord root="D"/>day or by <chord root="G"/>night<chord root="A"/>,<br/>
+        <chord root="D"/>Waking or <chord root="B" structure="min7"/>sleeping, Thy <chord root="G" structure="add9"/>presence my <chord root="D"/>light.
       </lines>
     </verse>
     <verse name="v2">
       <lines>
-        <chord name="D"/>Be Thou my <chord name="Bm7"/>wisdom, be <chord name="G"/>Thou my true <chord name="D"/>Word,<br/>
-        <chord name="A"/>I ever <chord name="Bm7"/>with Thee and <chord name="G"/>Thou with me, <chord name="A"/>Lord;<br/>
-        <chord name="Gmaj7"/>Thou my great <chord name="F#m7"/>Father, and <chord name="D"/>I thy true <chord name="G"/>son<chord name="A"/>,<br/>
-        <chord name="D"/>Thou in me <chord name="Bm7"/>dwelling, and <chord name="G2"/>I with Thee <chord name="D"/>one.
+        <chord root="D"/>Be Thou my <chord root="B" structure="min7"/>wisdom, be <chord root="G"/>Thou my true <chord root="D"/>Word,<br/>
+        <chord root="A"/>I ever <chord root="B" structure="min7"/>with Thee and <chord root="G"/>Thou with me, <chord root="A"/>Lord;<br/>
+        <chord root="G" structure="maj7"/>Thou my great <chord root="F#" structure="min7"/>Father, and <chord root="D"/>I thy true <chord root="G"/>son<chord root="A"/>,<br/>
+        <chord root="D"/>Thou in me <chord root="B" structure="min7"/>dwelling, and <chord root="G" structure="add9"/>I with Thee <chord root="D"/>one.
       </lines>
     </verse>
     <verse name="v3">
       <lines>
-        <chord name="E"/>Riches I <chord name="C#m7"/>heed not, nor <chord name="A"/>man's empty <chord name="E"/>praise,<br/>
-        <chord name="B"/>Thou mine In<chord name="C#m7"/>heritance <chord name="A"/>now and al<chord name="B"/>ways;<br/>
-        <chord name="Amaj7"/>Thou and Thou <chord name="G#m7"/>only, <chord name="E"/>first in my <chord name="A"/>heart<chord name="B"/>,<br/>
-        <chord name="E"/>High King of <chord name="C#m7"/>heaven, my <chord name="A2"/>Treasure Thou <chord name="E"/>art.
+        <chord root="E"/>Riches I <chord root="C#" structure="min7"/>heed not, nor <chord root="A"/>man's empty <chord root="E"/>praise,<br/>
+        <chord root="B"/>Thou mine In<chord root="C#" structure="min7"/>heritance <chord root="A"/>now and al<chord root="B"/>ways;<br/>
+        <chord root="A" structure="maj7"/>Thou and Thou <chord root="G#" structure="min7"/>only, <chord root="E"/>first in my <chord root="A"/>heart<chord root="B"/>,<br/>
+        <chord root="E"/>High King of <chord root="C#" structure="min7"/>heaven, my <chord root="A" structure="add9"/>Treasure Thou <chord root="E"/>art.
       </lines>
     </verse>
     <verse name="v4">
       <lines>
-        <chord name="E"/>High King of <chord name="C#m7"/>heaven my <chord name="A"/>victory <chord name="E"/>won,<br/>
-        <chord name="B"/>May I reach <chord name="C#m7"/>heaven's joys, <chord name="A"/>O bright heav'n's <chord name="B"/>Sun;<br/>
-        <chord name="Amaj7"/>Heart of my <chord name="G#m7"/>own heart, what<chord name="E"/>ever be<chord name="A"/>fall<chord name="B"/>,<br/>
-        <chord name="E"/>Still be my <chord name="C#m7"/>Vision, O <chord name="A2"/>Ruler of <chord name="E"/>all.
+        <chord root="E"/>High King of <chord root="C#" structure="min7"/>heaven my <chord root="A"/>victory <chord root="E"/>won,<br/>
+        <chord root="B"/>May I reach <chord root="C#" structure="min7"/>heaven's joys, <chord root="A"/>O bright heav'n's <chord root="B"/>Sun;<br/>
+        <chord root="A" structure="maj7"/>Heart of my <chord root="G#" structure="min7"/>own heart, what<chord root="E"/>ever be<chord root="A"/>fall<chord root="B"/>,<br/>
+        <chord root="E"/>Still be my <chord root="C#" structure="min7"/>Vision, O <chord root="A" structure="add9"/>Ruler of <chord root="E"/>all.
       </lines>
     </verse>
   </lyrics>

--- a/songs/Christ Arose.xml
+++ b/songs/Christ Arose.xml
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../stylesheets/openlyrics.css" type="text/css"?>
-<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.8" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:48.587349">
+<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.9" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:48.587349">
   <properties>
     <titles>
       <title>Christ Arose</title>
@@ -20,29 +20,29 @@
   <lyrics>
     <verse name="v1">
       <lines>
-        <chord name="Bb"/>Low in the grave He lay, <chord name="F"/>Jesus my <chord name="Eb"/>Sav<chord name="Bb"/>ior!<br/>
-        <chord name="Eb"/>Waiting the <chord name="Bb"/>coming day, <chord name="Gm/Bb"/>Je<chord name="C"/>sus my <chord name="F"/>Lord!
+        <chord root="Bb"/>Low in the grave He lay, <chord root="F"/>Jesus my <chord root="Eb"/>Sav<chord root="Bb"/>ior!<br/>
+        <chord root="Eb"/>Waiting the <chord root="Bb"/>coming day, <chord root="G" structure="min" bass="Bb"/>Je<chord root="C"/>sus my <chord root="F"/>Lord!
       </lines>
     </verse>
     <verse name="c">
       <lines>
-        (Spirited!) <chord name="Bb"/>Up from the grave He arose,<br/>
-        With a mighty <chord name="Cm"/>triumph o'er His <chord name="Bb"/>foes;<br/>
-        He a<chord name="F"/>rose a victor from the <chord name="Gm"/>dark <chord name="Eb"/>do<chord name="Bb"/>main,<br/>
-        And He <chord name="Eb"/>lives for<chord name="C"/>ever with His <chord name="F"/>saints <chord name="C7/G"/>to   <chord name="F/A"/>reign,<br/>
-        He a<chord name="Bb"/>rose! He a<chord name="Eb"/>rose! Halle<chord name="Bb"/>lujah! <chord name="F"/>Christ a<chord name="Bb"/>rose!
+        (Spirited!) <chord root="Bb"/>Up from the grave He arose,<br/>
+        With a mighty <chord root="C" structure="min"/>triumph o'er His <chord root="Bb"/>foes;<br/>
+        He a<chord root="F"/>rose a victor from the <chord root="G" structure="min"/>dark <chord root="Eb"/>do<chord root="Bb"/>main,<br/>
+        And He <chord root="Eb"/>lives for<chord root="C"/>ever with His <chord root="F"/>saints <chord root="C" structure="dom7" bass="G"/>to <chord root="F" bass="A"/>reign,<br/>
+        He a<chord root="Bb"/>rose! He a<chord root="Eb"/>rose! Halle<chord root="Bb"/>lujah! <chord root="F"/>Christ a<chord root="Bb"/>rose!
       </lines>
     </verse>
     <verse name="v2">
       <lines>
-        <chord name="Bb"/>Vainly they watch His bed, <chord name="F"/>Jesus my <chord name="Eb"/>Sav<chord name="Bb"/>ior!<br/>
-        <chord name="Eb"/>Vainly they <chord name="Bb"/>seal the dead, <chord name="Gm/Bb"/>Je<chord name="C"/>sus my <chord name="F"/>Lord!
+        <chord root="Bb"/>Vainly they watch His bed, <chord root="F"/>Jesus my <chord root="Eb"/>Sav<chord root="Bb"/>ior!<br/>
+        <chord root="Eb"/>Vainly they <chord root="Bb"/>seal the dead, <chord root="G" structure="min" bass="Bb"/>Je<chord root="C"/>sus my <chord root="F"/>Lord!
       </lines>
     </verse>
     <verse name="v3">
       <lines>
-        <chord name="Bb"/>Death cannot keep his prey, <chord name="F"/>Jesus my <chord name="Eb"/>Sav<chord name="Bb"/>ior!<br/>
-        <chord name="Eb"/>He tore the <chord name="Bb"/>bars away, <chord name="Gm/Bb"/>Je<chord name="C"/>sus my <chord name="F"/>Lord!
+        <chord root="Bb"/>Death cannot keep his prey, <chord root="F"/>Jesus my <chord root="Eb"/>Sav<chord root="Bb"/>ior!<br/>
+        <chord root="Eb"/>He tore the <chord root="Bb"/>bars away, <chord root="G" structure="min" bass="Bb"/>Je<chord root="C"/>sus my <chord root="F"/>Lord!
       </lines>
     </verse>
   </lyrics>

--- a/songs/Come Thou Fount.xml
+++ b/songs/Come Thou Fount.xml
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../stylesheets/openlyrics.css" type="text/css"?>
-<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.8" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:48.675831">
+<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.9" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:48.675831">
   <properties>
     <titles>
       <title>Come Thou Fount</title>
@@ -18,26 +18,26 @@
   <lyrics>
     <verse name="v1">
       <lines>
-        Come, Thou <chord name="D"/>Fount of every <chord name="A"/>blessing, Tune my <chord name="G"/>heart to sing Thy <chord name="D"/>grace;<br/>
-        Streams of <chord name="D"/>mercy, never <chord name="A"/>ceasing, Call for <chord name="G"/>songs of loudest <chord name="D"/>praise.<br/>
-        Teach me <chord name="D"/>some melodious <chord name="A"/>sonnet, Sung by <chord name="G"/>flaming tongues <chord name="D"/>above;<br/>
-        Praise the <chord name="D"/>mount, I'm fixed u<chord name="A"/>pon it, Mount of <chord name="G"/>Thy redeeming <chord name="D"/>love.
+        Come, Thou <chord root="D"/>Fount of every <chord root="A"/>blessing, Tune my <chord root="G"/>heart to sing Thy <chord root="D"/>grace;<br/>
+        Streams of <chord root="D"/>mercy, never <chord root="A"/>ceasing, Call for <chord root="G"/>songs of loudest <chord root="D"/>praise.<br/>
+        Teach me <chord root="D"/>some melodious <chord root="A"/>sonnet, Sung by <chord root="G"/>flaming tongues <chord root="D"/>above;<br/>
+        Praise the <chord root="D"/>mount, I'm fixed u<chord root="A"/>pon it, Mount of <chord root="G"/>Thy redeeming <chord root="D"/>love.
       </lines>
     </verse>
     <verse name="v2">
       <lines>
-        Here I <chord name="D"/>raise mine Ebe<chord name="A"/>nezer, Hither <chord name="G"/>by Thy great help I <chord name="D"/>come;<br/>
-        And I <chord name="D"/>hope by Thy good <chord name="A"/>pleasure, Safely <chord name="G"/>to arrive at <chord name="D"/>home.<br/>
-        Jesus <chord name="D"/>sought me when a <chord name="A"/>stranger, Wandering <chord name="G"/>from the fold of <chord name="D"/>God;<br/>
-        He to <chord name="D"/>rescue me from <chord name="A"/>danger, Inter<chord name="G"/>posed His precious <chord name="D"/>blood.
+        Here I <chord root="D"/>raise mine Ebe<chord root="A"/>nezer, Hither <chord root="G"/>by Thy great help I <chord root="D"/>come;<br/>
+        And I <chord root="D"/>hope by Thy good <chord root="A"/>pleasure, Safely <chord root="G"/>to arrive at <chord root="D"/>home.<br/>
+        Jesus <chord root="D"/>sought me when a <chord root="A"/>stranger, Wandering <chord root="G"/>from the fold of <chord root="D"/>God;<br/>
+        He to <chord root="D"/>rescue me from <chord root="A"/>danger, Inter<chord root="G"/>posed His precious <chord root="D"/>blood.
       </lines>
     </verse>
     <verse name="v3">
       <lines>
-        Oh to <chord name="D"/>grace how great a <chord name="A"/>debtor, Daily <chord name="G"/>I'm constrained to <chord name="D"/>be;<br/>
-        Let Thy <chord name="D"/>goodness, like a <chord name="A"/>fetter, Bind my <chord name="G"/>wandering heart to <chord name="D"/>Thee.<br/>
-        Prone to <chord name="D"/>wander, Lord I <chord name="A"/>feel it, Prone to <chord name="G"/>leave the God I <chord name="D"/>love;<br/>
-        Here's my <chord name="D"/>heart, Oh take and <chord name="A"/>seal it, Seal it <chord name="G"/>for Thy courts a<chord name="D"/>bove.
+        Oh to <chord root="D"/>grace how great a <chord root="A"/>debtor, Daily <chord root="G"/>I'm constrained to <chord root="D"/>be;<br/>
+        Let Thy <chord root="D"/>goodness, like a <chord root="A"/>fetter, Bind my <chord root="G"/>wandering heart to <chord root="D"/>Thee.<br/>
+        Prone to <chord root="D"/>wander, Lord I <chord root="A"/>feel it, Prone to <chord root="G"/>leave the God I <chord root="D"/>love;<br/>
+        Here's my <chord root="D"/>heart, Oh take and <chord root="A"/>seal it, Seal it <chord root="G"/>for Thy courts a<chord root="D"/>bove.
       </lines>
     </verse>
   </lyrics>

--- a/songs/Crown Him With Many Crowns.xml
+++ b/songs/Crown Him With Many Crowns.xml
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../stylesheets/openlyrics.css" type="text/css"?>
-<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.8" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:48.800516">
+<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.9" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:48.800516">
   <properties>
     <titles>
       <title>Crown Him With Many Crowns</title>
@@ -19,26 +19,26 @@
   <lyrics>
     <verse name="v1">
       <lines>
-        <chord name="C"/>Crown Him with <chord name="Am"/>many <chord name="F"/>crowns, the <chord name="Em"/>Lamb u<chord name="F"/>pon His <chord name="Gsus"/>throne;<br/>
-        <chord name="G"/>Hark <chord name="C"/>how the <chord name="Am"/>heavenly <chord name="D"/>anthem <chord name="G"/>drowns, <chord name="C"/>all <chord name="G"/>music <chord name="D"/>but its <chord name="G"/>own;<br/>
-        A<chord name="C"/>wake my soul and <chord name="F"/>sing, of <chord name="D"/>Him who died for <chord name="G"/>Thee,<br/>
-        And <chord name="C"/>hail Him <chord name="F"/>as Thy <chord name="Dm7"/>matchless <chord name="C"/>King through <chord name="Dm7"/>all e<chord name="G"/>terni<chord name="C"/>ty.
+        <chord root="C"/>Crown Him with <chord root="A" structure="min"/>many <chord root="F"/>crowns, the <chord root="E" structure="min"/>Lamb u<chord root="F"/>pon His <chord root="G" structure="sus4"/>throne;<br/>
+        <chord root="G"/>Hark <chord root="C"/>how the <chord root="A" structure="min"/>heavenly <chord root="D"/>anthem <chord root="G"/>drowns, <chord root="C"/>all <chord root="G"/>music <chord root="D"/>but its <chord root="G"/>own;<br/>
+        A<chord root="C"/>wake my soul and <chord root="F"/>sing, of <chord root="D"/>Him who died for <chord root="G"/>Thee,<br/>
+        And <chord root="C"/>hail Him <chord root="F"/>as Thy <chord root="D" structure="min7"/>matchless <chord root="C"/>King through <chord root="D" structure="min7"/>all e<chord root="G"/>terni<chord root="C"/>ty.
       </lines>
     </verse>
     <verse name="v2">
       <lines>
-        <chord name="C"/>Crown Him the <chord name="Am"/>Lord of <chord name="F"/>life, who <chord name="Em"/>triumphed <chord name="F"/>o’er the <chord name="Gsus"/>grave;<br/>
-        <chord name="G"/>And <chord name="C"/>rose vic<chord name="Am"/>torious <chord name="D"/>in the <chord name="G"/>strife, <chord name="C"/>for <chord name="G"/>those He <chord name="D"/>came to <chord name="G"/>save;<br/>
-        His <chord name="C"/>glories now we <chord name="F"/>sing, who <chord name="D"/>died and rose on <chord name="G"/>high,<br/>
-        Who <chord name="C"/>died e<chord name="F"/>ternal <chord name="Dm7"/>life to <chord name="C"/>bring and <chord name="Dm7"/>lives that <chord name="G"/>death may <chord name="C"/>die.
+        <chord root="C"/>Crown Him the <chord root="A" structure="min"/>Lord of <chord root="F"/>life, who <chord root="E" structure="min"/>triumphed <chord root="F"/>o’er the <chord root="G" structure="sus4"/>grave;<br/>
+        <chord root="G"/>And <chord root="C"/>rose vic<chord root="A" structure="min"/>torious <chord root="D"/>in the <chord root="G"/>strife, <chord root="C"/>for <chord root="G"/>those He <chord root="D"/>came to <chord root="G"/>save;<br/>
+        His <chord root="C"/>glories now we <chord root="F"/>sing, who <chord root="D"/>died and rose on <chord root="G"/>high,<br/>
+        Who <chord root="C"/>died e<chord root="F"/>ternal <chord root="D" structure="min7"/>life to <chord root="C"/>bring and <chord root="D" structure="min7"/>lives that <chord root="G"/>death may <chord root="C"/>die.
       </lines>
     </verse>
     <verse name="v3">
       <lines>
-        <chord name="C"/>Crown Him the <chord name="Am"/>Lord of <chord name="F"/>love, be<chord name="Em"/>hold His <chord name="F"/>hands and <chord name="Gsus"/>side;<br/>
-        <chord name="G"/>Rich <chord name="C"/>wounds yet <chord name="Am"/>visi<chord name="D"/>ble a<chord name="G"/>bove, <chord name="C"/>in <chord name="G"/>beauty <chord name="D"/>glori<chord name="G"/>fied;<br/>
-        All <chord name="C"/>hail Redeemer <chord name="F"/>hail, for <chord name="D"/>Thou hast died for <chord name="G"/>me,<br/>
-        Thy <chord name="C"/>praise shall <chord name="F"/>never, <chord name="Dm7"/>never <chord name="C"/>fail, through<chord name="Dm7"/>out e<chord name="G"/>terni<chord name="C"/>ty.
+        <chord root="C"/>Crown Him the <chord root="A" structure="min"/>Lord of <chord root="F"/>love, be<chord root="E" structure="min"/>hold His <chord root="F"/>hands and <chord root="G" structure="sus4"/>side;<br/>
+        <chord root="G"/>Rich <chord root="C"/>wounds yet <chord root="A" structure="min"/>visi<chord root="D"/>ble a<chord root="G"/>bove, <chord root="C"/>in <chord root="G"/>beauty <chord root="D"/>glori<chord root="G"/>fied;<br/>
+        All <chord root="C"/>hail Redeemer <chord root="F"/>hail, for <chord root="D"/>Thou hast died for <chord root="G"/>me,<br/>
+        Thy <chord root="C"/>praise shall <chord root="F"/>never, <chord root="D" structure="min7"/>never <chord root="C"/>fail, through<chord root="D" structure="min7"/>out e<chord root="G"/>terni<chord root="C"/>ty.
       </lines>
     </verse>
   </lyrics>

--- a/songs/Great Is Thy Faithfulness.xml
+++ b/songs/Great Is Thy Faithfulness.xml
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../stylesheets/openlyrics.css" type="text/css"?>
-<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.8" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:48.907924">
+<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.9" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:48.907924">
   <properties>
     <titles>
       <title>Great Is Thy Faithfulness</title>
@@ -18,34 +18,34 @@
   <lyrics>
     <verse name="v1">
       <lines>
-        <chord name="A"/>Great is Thy <chord name="E"/>faithfulness, <chord name="D"/>O God my <chord name="A"/>Father,<br/>
-        <chord name="D"/>There is no <chord name="A"/>shadow of <chord name="B7"/>turning with <chord name="E"/>Thee;<br/>
-        <chord name="E7"/>Thou changest <chord name="A"/>not, Thy com<chord name="A7"/>passions they <chord name="D"/>fail not;<br/>
-        <chord name="Bm7"/>As Thou hast <chord name="A"/>been, Thou for<chord name="D"/>ever <chord name="E"/>will <chord name="A"/>be.
+        <chord root="A"/>Great is Thy <chord root="E"/>faithfulness, <chord root="D"/>O God my <chord root="A"/>Father,<br/>
+        <chord root="D"/>There is no <chord root="A"/>shadow of <chord root="B" structure="dom7"/>turning with <chord root="E"/>Thee;<br/>
+        <chord root="E" structure="dom7"/>Thou changest <chord root="A"/>not, Thy com<chord root="A" structure="dom7"/>passions they <chord root="D"/>fail not;<br/>
+        <chord root="B" structure="min7"/>As Thou hast <chord root="A"/>been, Thou for<chord root="D"/>ever <chord root="E"/>will <chord root="A"/>be.
       </lines>
     </verse>
     <verse name="c">
       <lines>
-        <chord name="E"/>Great is Thy <chord name="A"/>faithfulness! <chord name="F#"/>Great is Thy <chord name="Bm"/>faithfulness!<br/>
-        <chord name="E"/>Morning by <chord name="A"/>morning new <chord name="B7"/>mercies I <chord name="E"/>see;<br/>
-        <chord name="E7"/>All I have <chord name="A"/>needed, Thy <chord name="A7"/>hands hath pro<chord name="D"/>vided--<br/>
-        <chord name="B7"/>Great is Thy <chord name="A"/>faithfulness, <chord name="D"/>Lord un<chord name="E"/>to <chord name="A"/>me!
+        <chord root="E"/>Great is Thy <chord root="A"/>faithfulness! <chord root="F#"/>Great is Thy <chord root="B" structure="min"/>faithfulness!<br/>
+        <chord root="E"/>Morning by <chord root="A"/>morning new <chord root="B" structure="dom7"/>mercies I <chord root="E"/>see;<br/>
+        <chord root="E" structure="dom7"/>All I have <chord root="A"/>needed, Thy <chord root="A" structure="dom7"/>hands hath pro<chord root="D"/>vided--<br/>
+        <chord root="B" structure="dom7"/>Great is Thy <chord root="A"/>faithfulness, <chord root="D"/>Lord un<chord root="E"/>to <chord root="A"/>me!
       </lines>
     </verse>
     <verse name="v2">
       <lines>
-        <chord name="A"/>Summer and <chord name="E"/>winter and <chord name="D"/>springtime and <chord name="A"/>harvest,<br/>
-        <chord name="D"/>Sun, moon and <chord name="A"/>stars in their <chord name="B7"/>courses a<chord name="E"/>bove<br/>
-        <chord name="E7"/>Join with all <chord name="A"/>nature in <chord name="A7"/>manifold <chord name="D"/>witness<br/>
-        <chord name="Bm7"/>To Thy great <chord name="A"/>faithfulness, <chord name="D"/>mercy <chord name="E"/>and <chord name="A"/>love.
+        <chord root="A"/>Summer and <chord root="E"/>winter and <chord root="D"/>springtime and <chord root="A"/>harvest,<br/>
+        <chord root="D"/>Sun, moon and <chord root="A"/>stars in their <chord root="B" structure="dom7"/>courses a<chord root="E"/>bove<br/>
+        <chord root="E" structure="dom7"/>Join with all <chord root="A"/>nature in <chord root="A" structure="dom7"/>manifold <chord root="D"/>witness<br/>
+        <chord root="B" structure="min7"/>To Thy great <chord root="A"/>faithfulness, <chord root="D"/>mercy <chord root="E"/>and <chord root="A"/>love.
       </lines>
     </verse>
     <verse name="v3">
       <lines>
-        <chord name="A"/>Pardon for <chord name="E"/>sin and a <chord name="D"/>peace that en<chord name="A"/>dureth,<br/>
-        <chord name="D"/>Thy own dear <chord name="A"/>presence to <chord name="B7"/>cheer and to <chord name="E"/>guide;<br/>
-        <chord name="E7"/>Strength for to<chord name="A"/>day and bright <chord name="A7"/>hope for to<chord name="D"/>morrow,<br/>
-        <chord name="Bm7"/>Blessings all <chord name="A"/>mine with ten <chord name="D"/>thousands <chord name="E"/>be<chord name="A"/>side.
+        <chord root="A"/>Pardon for <chord root="E"/>sin and a <chord root="D"/>peace that en<chord root="A"/>dureth,<br/>
+        <chord root="D"/>Thy own dear <chord root="A"/>presence to <chord root="B" structure="dom7"/>cheer and to <chord root="E"/>guide;<br/>
+        <chord root="E" structure="dom7"/>Strength for to<chord root="A"/>day and bright <chord root="A" structure="dom7"/>hope for to<chord root="D"/>morrow,<br/>
+        <chord root="B" structure="min7"/>Blessings all <chord root="A"/>mine with ten <chord root="D"/>thousands <chord root="E"/>be<chord root="A"/>side.
       </lines>
     </verse>
   </lyrics>

--- a/songs/Hava Nagila.xml
+++ b/songs/Hava Nagila.xml
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../stylesheets/openlyrics.css" type="text/css"?>
-<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.8" createdIn="Trac 0.11.2" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:49.006882">
+<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.9" createdIn="Trac 0.11.2" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:49.006882">
   <properties>
     <titles>
       <title lang="he">הבה נגילה</title>
@@ -18,7 +18,6 @@
     </themes>
   </properties>
   <lyrics>
-
     <verse name="v1" lang="he">
       <lines>
         הבה נגילה<br/>
@@ -40,7 +39,6 @@
         Let's rejoice and be happy
       </lines>
     </verse>
-
     <verse name="c" lang="he">
       <lines>
         הבה נרננה<br/>
@@ -62,12 +60,10 @@
         Let's sing and be happy
       </lines>
     </verse>
-
     <verse name="b" lang="he">
       <lines>
         !עורו, עורו אחים<br/>
-        עורו אחים בלב שמח<br/>
-        <br/>
+        עורו אחים בלב שמח<br/><br/>
         !עורו אחים, עורו אחים<br/>
         בלב שמח
       </lines>
@@ -75,8 +71,7 @@
     <verse name="b" lang="he" translit="en">
       <lines>
         Uru, uru achim!<br/>
-        Uru achim b'lev sameach<br/>
-        <br/>
+        Uru achim b'lev sameach<br/><br/>
         Uru achim, uru achim!<br/>
         B'lev sameach
       </lines>
@@ -84,12 +79,10 @@
     <verse name="b" lang="en">
       <lines>
         Awake, awake, brothers!<br/>
-        Awake brothers with a happy heart<br/>
-        <br/>
+        Awake brothers with a happy heart<br/><br/>
         Awake, brothers, awake, brothers!<br/>
         With a happy heart
       </lines>
     </verse>
-
   </lyrics>
 </song>

--- a/songs/Hava Nagila.xml
+++ b/songs/Hava Nagila.xml
@@ -63,7 +63,7 @@
     <verse name="b" lang="he">
       <lines>
         !עורו, עורו אחים<br/>
-        עורו אחים בלב שמח<br/><br/>
+        עורו אחים בלב שמח<br/>
         !עורו אחים, עורו אחים<br/>
         בלב שמח
       </lines>
@@ -79,7 +79,7 @@
     <verse name="b" lang="en">
       <lines>
         Awake, awake, brothers!<br/>
-        Awake brothers with a happy heart<br/><br/>
+        Awake brothers with a happy heart<br/>
         Awake, brothers, awake, brothers!<br/>
         With a happy heart
       </lines>

--- a/songs/He Leadeth Me.xml
+++ b/songs/He Leadeth Me.xml
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../stylesheets/openlyrics.css" type="text/css"?>
-<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.8" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:49.095641">
+<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.9" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:49.095641">
   <properties>
     <titles>
       <title>He Leadeth Me</title>
@@ -19,26 +19,26 @@
   <lyrics>
     <verse name="v1">
       <lines>
-        He <chord name="D"/>leadeth me! <chord name="D/F#"/>O    <chord name="G"/>blessed thought! O <chord name="D"/>words with heavenly comfort <chord name="A"/>fraught!<br/>
-        What<chord name="D"/>e'er I do, <chord name="D/F#"/>where'<chord name="G"/>er I be, Still <chord name="D"/>'tis God's <chord name="Bm"/>hand that <chord name="D"/>lea<chord name="A"/>deth <chord name="D"/>me.
+        He <chord root="D"/>leadeth me! <chord root="D" bass="F#"/>O <chord root="G"/>blessed thought! O <chord root="D"/>words with heavenly comfort <chord root="A"/>fraught!<br/>
+        What<chord root="D"/>e'er I do, <chord root="D" bass="F#"/>where'<chord root="G"/>er I be, Still <chord root="D"/>'tis God's <chord root="B" structure="min"/>hand that <chord root="D"/>lea<chord root="A"/>deth <chord root="D"/>me.
       </lines>
     </verse>
     <verse name="v2">
       <lines>
-        Lord, <chord name="D"/>I would clasp <chord name="D/F#"/>Thy  <chord name="G"/>hand in mine, Nor <chord name="D"/>ever murmur nor re<chord name="A"/>pine,<br/>
-        Con<chord name="D"/>tent, what<chord name="D/F#"/>ever  <chord name="G"/>lot I see, Since <chord name="D"/>God through <chord name="Bm"/>Jordan <chord name="D"/>lea<chord name="A"/>deth <chord name="D"/>me.
+        Lord, <chord root="D"/>I would clasp <chord root="D" bass="F#"/>Thy <chord root="G"/>hand in mine, Nor <chord root="D"/>ever murmur nor re<chord root="A"/>pine,<br/>
+        Con<chord root="D"/>tent, what<chord root="D" bass="F#"/>ever <chord root="G"/>lot I see, Since <chord root="D"/>God through <chord root="B" structure="min"/>Jordan <chord root="D"/>lea<chord root="A"/>deth <chord root="D"/>me.
       </lines>
     </verse>
     <verse name="v3">
       <lines>
-        And <chord name="D"/>when my task o<chord name="D/F#"/>n    <chord name="G"/>earth is done, When <chord name="D"/>by Thy grace the victory's <chord name="A"/>won,<br/>
-        E'en <chord name="D"/>death's cold wave <chord name="D/F#"/>I    <chord name="G"/>will not flee, Since <chord name="D"/>God through <chord name="Bm"/>Jordan <chord name="D"/>lea<chord name="A"/>deth <chord name="D"/>me.
+        And <chord root="D"/>when my task o<chord root="D" bass="F#"/>n <chord root="G"/>earth is done, When <chord root="D"/>by Thy grace the victory's <chord root="A"/>won,<br/>
+        E'en <chord root="D"/>death's cold wave <chord root="D" bass="F#"/>I <chord root="G"/>will not flee, Since <chord root="D"/>God through <chord root="B" structure="min"/>Jordan <chord root="D"/>lea<chord root="A"/>deth <chord root="D"/>me.
       </lines>
     </verse>
     <verse name="c">
       <lines>
-        He <chord name="D"/>leadeth <chord name="A"/>me, He <chord name="D"/>lead<chord name="G"/>eth <chord name="D"/>me; By His own <chord name="Bm"/>hand He <chord name="D"/>leadeth <chord name="A"/>me:<br/>
-        His <chord name="D"/>faithful <chord name="A"/>follower <chord name="D"/>I <chord name="G"/>would <chord name="D"/>be, For <chord name="Bm"/>by His <chord name="D"/>hand He <chord name="A"/>leadeth <chord name="D"/>me.
+        He <chord root="D"/>leadeth <chord root="A"/>me, He <chord root="D"/>lead<chord root="G"/>eth <chord root="D"/>me; By His own <chord root="B" structure="min"/>hand He <chord root="D"/>leadeth <chord root="A"/>me:<br/>
+        His <chord root="D"/>faithful <chord root="A"/>follower <chord root="D"/>I <chord root="G"/>would <chord root="D"/>be, For <chord root="B" structure="min"/>by His <chord root="D"/>hand He <chord root="A"/>leadeth <chord root="D"/>me.
       </lines>
     </verse>
   </lyrics>

--- a/songs/Holy Holy Holy.xml
+++ b/songs/Holy Holy Holy.xml
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../stylesheets/openlyrics.css" type="text/css"?>
-<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.8" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:49.184508">
+<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.9" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:49.184508">
   <properties>
     <titles>
       <title>Holy Holy Holy</title>
@@ -18,34 +18,34 @@
   <lyrics>
     <verse name="v1">
       <lines>
-        <chord name="D"/>Holy, <chord name="Bm"/>holy, <chord name="A"/>ho<chord name="D"/>ly, <chord name="G"/>Lord God Al<chord name="D"/>mighty,<br/>
-        <chord name="A"/>Early in the <chord name="Bm"/>mor<chord name="A"/>ning my <chord name="E"/>song shall rise to <chord name="A"/>Thee;<br/>
-        <chord name="D"/>Holy, <chord name="Bm"/>holy, <chord name="A"/>ho<chord name="D"/>ly, <chord name="G"/>merciful and <chord name="D"/>mighty,<br/>
-        <chord name="Bm"/>God <chord name="Bm/A"/>in three <chord name="G"/>per<chord name="D"/>sons, <chord name="Em"/>blessed <chord name="A"/>Trini<chord name="D"/>ty.
+        <chord root="D"/>Holy, <chord root="B" structure="min"/>holy, <chord root="A"/>ho<chord root="D"/>ly, <chord root="G"/>Lord God Al<chord root="D"/>mighty,<br/>
+        <chord root="A"/>Early in the <chord root="B" structure="min"/>mor<chord root="A"/>ning my <chord root="E"/>song shall rise to <chord root="A"/>Thee;<br/>
+        <chord root="D"/>Holy, <chord root="B" structure="min"/>holy, <chord root="A"/>ho<chord root="D"/>ly, <chord root="G"/>merciful and <chord root="D"/>mighty,<br/>
+        <chord root="B" structure="min"/>God <chord root="B" structure="min" bass="A"/>in three <chord root="G"/>per<chord root="D"/>sons, <chord root="E" structure="min"/>blessed <chord root="A"/>Trini<chord root="D"/>ty.
       </lines>
     </verse>
     <verse name="v2">
       <lines>
-        <chord name="D"/>Holy, <chord name="Bm"/>holy, <chord name="A"/>ho<chord name="D"/>ly, <chord name="G"/>all the saints a<chord name="D"/>dore Thee,<br/>
-        <chord name="A"/>Casting down their <chord name="Bm"/>golden <chord name="A"/>crowns a<chord name="E"/>round the glassy <chord name="A"/>sea;<br/>
-        <chord name="D"/>Cheru<chord name="Bm"/>bim and <chord name="A"/>sera<chord name="D"/>phim, <chord name="G"/>falling down be<chord name="D"/>fore Thee,<br/>
-        <chord name="Bm"/>Which, <chord name="Bm/A"/>wert and <chord name="G"/>art <chord name="D"/>and <chord name="Em"/>ever <chord name="A"/>more shall <chord name="D"/>be.
+        <chord root="D"/>Holy, <chord root="B" structure="min"/>holy, <chord root="A"/>ho<chord root="D"/>ly, <chord root="G"/>all the saints a<chord root="D"/>dore Thee,<br/>
+        <chord root="A"/>Casting down their <chord root="B" structure="min"/>golden <chord root="A"/>crowns a<chord root="E"/>round the glassy <chord root="A"/>sea;<br/>
+        <chord root="D"/>Cheru<chord root="B" structure="min"/>bim and <chord root="A"/>sera<chord root="D"/>phim, <chord root="G"/>falling down be<chord root="D"/>fore Thee,<br/>
+        <chord root="B" structure="min"/>Which, <chord root="B" structure="min" bass="A"/>wert and <chord root="G"/>art <chord root="D"/>and <chord root="E" structure="min"/>ever <chord root="A"/>more shall <chord root="D"/>be.
       </lines>
     </verse>
     <verse name="v3">
       <lines>
-        <chord name="D"/>Holy, <chord name="Bm"/>holy, <chord name="A"/>ho<chord name="D"/>ly, <chord name="G"/>though the darkness <chord name="D"/>hide Thee,<br/>
-        <chord name="A"/>Though the eye of <chord name="Bm"/>sinful <chord name="A"/>men Thy <chord name="E"/>Glory may not <chord name="A"/>see;<br/>
-        <chord name="D"/>Only <chord name="Bm"/>Thou art <chord name="A"/>ho<chord name="D"/>ly, <chord name="G"/>there is none be<chord name="D"/>side Thee,<br/>
-        <chord name="Bm"/>Per<chord name="Bm/A"/>fect in <chord name="G"/>power, <chord name="D"/>in <chord name="Em"/>love and <chord name="A"/>puri<chord name="D"/>ty.
+        <chord root="D"/>Holy, <chord root="B" structure="min"/>holy, <chord root="A"/>ho<chord root="D"/>ly, <chord root="G"/>though the darkness <chord root="D"/>hide Thee,<br/>
+        <chord root="A"/>Though the eye of <chord root="B" structure="min"/>sinful <chord root="A"/>men Thy <chord root="E"/>Glory may not <chord root="A"/>see;<br/>
+        <chord root="D"/>Only <chord root="B" structure="min"/>Thou art <chord root="A"/>ho<chord root="D"/>ly, <chord root="G"/>there is none be<chord root="D"/>side Thee,<br/>
+        <chord root="B" structure="min"/>Per<chord root="B" structure="min" bass="A"/>fect in <chord root="G"/>power, <chord root="D"/>in <chord root="E" structure="min"/>love and <chord root="A"/>puri<chord root="D"/>ty.
       </lines>
     </verse>
     <verse name="v4">
       <lines>
-        <chord name="D"/>Holy, <chord name="Bm"/>holy, <chord name="A"/>ho<chord name="D"/>ly, <chord name="G"/>Lord God Al<chord name="D"/>mighy,<br/>
-        <chord name="A"/>All Thy works shall <chord name="Bm"/>praise Thy <chord name="A"/>Name in <chord name="E"/>earth and sky and <chord name="A"/>sea;<br/>
-        <chord name="D"/>Holy, <chord name="Bm"/>holy, <chord name="A"/>ho<chord name="D"/>ly, <chord name="G"/>merciful and <chord name="D"/>mighty,<br/>
-        <chord name="Bm"/>God <chord name="Bm/A"/>in three <chord name="G"/>per<chord name="D"/>sons, <chord name="Em"/>blessed <chord name="A"/>Trini<chord name="D"/>ty.
+        <chord root="D"/>Holy, <chord root="B" structure="min"/>holy, <chord root="A"/>ho<chord root="D"/>ly, <chord root="G"/>Lord God Al<chord root="D"/>mighy,<br/>
+        <chord root="A"/>All Thy works shall <chord root="B" structure="min"/>praise Thy <chord root="A"/>Name in <chord root="E"/>earth and sky and <chord root="A"/>sea;<br/>
+        <chord root="D"/>Holy, <chord root="B" structure="min"/>holy, <chord root="A"/>ho<chord root="D"/>ly, <chord root="G"/>merciful and <chord root="D"/>mighty,<br/>
+        <chord root="B" structure="min"/>God <chord root="B" structure="min" bass="A"/>in three <chord root="G"/>per<chord root="D"/>sons, <chord root="E" structure="min"/>blessed <chord root="A"/>Trini<chord root="D"/>ty.
       </lines>
     </verse>
   </lyrics>

--- a/songs/How Firm A Foundation.xml
+++ b/songs/How Firm A Foundation.xml
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../stylesheets/openlyrics.css" type="text/css"?>
-<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.8" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:49.272273">
+<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.9" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:49.272273">
   <properties>
     <titles>
       <title>How Firm A Foundation</title>
@@ -19,42 +19,42 @@
   <lyrics>
     <verse name="v1">
       <lines>
-        How <chord name="G"/>firm <chord name="C"/>a foun<chord name="G"/>dation, ye <chord name="G"/>saints of the <chord name="D"/>Lord,<br/>
-        Is <chord name="G"/>laid <chord name="C"/>for your <chord name="G"/>faith <chord name="Em"/>in His <chord name="G/D"/>ex<chord name="D7"/>cellent <chord name="G"/>word!<br/>
-        What <chord name="G"/>more can He <chord name="Em"/>say than to <chord name="G"/>you He hath <chord name="D"/>said,<br/>
-        To <chord name="G"/>you <chord name="C"/>who for <chord name="G"/>re<chord name="Em"/>fuge to <chord name="G/D"/>Je<chord name="D7"/>sus hath <chord name="G"/>fled.
+        How <chord root="G"/>firm <chord root="C"/>a foun<chord root="G"/>dation, ye <chord root="G"/>saints of the <chord root="D"/>Lord,<br/>
+        Is <chord root="G"/>laid <chord root="C"/>for your <chord root="G"/>faith <chord root="E" structure="min"/>in His <chord root="G" bass="D"/>ex<chord root="D" structure="dom7"/>cellent <chord root="G"/>word!<br/>
+        What <chord root="G"/>more can He <chord root="E" structure="min"/>say than to <chord root="G"/>you He hath <chord root="D"/>said,<br/>
+        To <chord root="G"/>you <chord root="C"/>who for <chord root="G"/>re<chord root="E" structure="min"/>fuge to <chord root="G" bass="D"/>Je<chord root="D" structure="dom7"/>sus hath <chord root="G"/>fled.
       </lines>
     </verse>
     <verse name="v2">
       <lines>
-        "Fear <chord name="G"/>not, <chord name="C"/>I am <chord name="G"/>with thee, O <chord name="G"/>be not dis<chord name="D"/>mayed,<br/>
-        For <chord name="G"/>I <chord name="C"/>am your <chord name="G"/>God, <chord name="Em"/>and will <chord name="G/D"/>still <chord name="D7"/>give thee <chord name="G"/>aid;<br/>
-        I'll <chord name="G"/>strengthen thee, <chord name="Em"/>help thee and <chord name="G"/>cause thee to <chord name="D"/>stand,<br/>
-        Up<chord name="G"/>held <chord name="C"/>by My <chord name="G"/>right<chord name="Em"/>eous, om<chord name="G/D"/>ni<chord name="D7"/>potent <chord name="G"/>hand."
+        "Fear <chord root="G"/>not, <chord root="C"/>I am <chord root="G"/>with thee, O <chord root="G"/>be not dis<chord root="D"/>mayed,<br/>
+        For <chord root="G"/>I <chord root="C"/>am your <chord root="G"/>God, <chord root="E" structure="min"/>and will <chord root="G" bass="D"/>still <chord root="D" structure="dom7"/>give thee <chord root="G"/>aid;<br/>
+        I'll <chord root="G"/>strengthen thee, <chord root="E" structure="min"/>help thee and <chord root="G"/>cause thee to <chord root="D"/>stand,<br/>
+        Up<chord root="G"/>held <chord root="C"/>by My <chord root="G"/>right<chord root="E" structure="min"/>eous, om<chord root="G" bass="D"/>ni<chord root="D" structure="dom7"/>potent <chord root="G"/>hand."
       </lines>
     </verse>
     <verse name="v3">
       <lines>
-        "When <chord name="G"/>through <chord name="C"/>the deep <chord name="G"/>waters I <chord name="G"/>call thee to <chord name="D"/>go,<br/>
-        The <chord name="G"/>ri<chord name="C"/>vers of <chord name="G"/>sor<chord name="Em"/>row shall <chord name="G/D"/>not <chord name="D7"/>over<chord name="G"/>flow;<br/>
-        For I<chord name="G"/> will be <chord name="Em"/>with thee, thy <chord name="G"/>troubles to <chord name="D"/>bless,<br/>
-        And <chord name="G"/>sanc<chord name="C"/>tify <chord name="G"/>to <chord name="Em"/>thee thy <chord name="G/D"/>deep<chord name="D7"/>est dis<chord name="G"/>tress."
+        "When <chord root="G"/>through <chord root="C"/>the deep <chord root="G"/>waters I <chord root="G"/>call thee to <chord root="D"/>go,<br/>
+        The <chord root="G"/>ri<chord root="C"/>vers of <chord root="G"/>sor<chord root="E" structure="min"/>row shall <chord root="G" bass="D"/>not <chord root="D" structure="dom7"/>over<chord root="G"/>flow;<br/>
+        For I<chord root="G"/> will be <chord root="E" structure="min"/>with thee, thy <chord root="G"/>troubles to <chord root="D"/>bless,<br/>
+        And <chord root="G"/>sanc<chord root="C"/>tify <chord root="G"/>to <chord root="E" structure="min"/>thee thy <chord root="G" bass="D"/>deep<chord root="D" structure="dom7"/>est dis<chord root="G"/>tress."
       </lines>
     </verse>
     <verse name="v4">
       <lines>
-        "When <chord name="G"/>through <chord name="C"/>fiery <chord name="G"/>trials thy <chord name="G"/>pathway shall <chord name="D"/>lie,<br/>
-        My <chord name="G"/>grace, <chord name="C"/>all suf<chord name="G"/>fi<chord name="Em"/>cient shall <chord name="G/D"/>be  <chord name="D7"/>thy sup<chord name="G"/>ply;<br/>
-        The f<chord name="G"/>lame shall not <chord name="Em"/>hurt thee; I <chord name="G"/>only de<chord name="D"/>sign<br/>
-        Thy <chord name="G"/>dross <chord name="C"/>to con<chord name="G"/>sume, <chord name="Em"/>and thy <chord name="G/D"/>gold <chord name="D7"/>to re<chord name="G"/>fine."
+        "When <chord root="G"/>through <chord root="C"/>fiery <chord root="G"/>trials thy <chord root="G"/>pathway shall <chord root="D"/>lie,<br/>
+        My <chord root="G"/>grace, <chord root="C"/>all suf<chord root="G"/>fi<chord root="E" structure="min"/>cient shall <chord root="G" bass="D"/>be <chord root="D" structure="dom7"/>thy sup<chord root="G"/>ply;<br/>
+        The f<chord root="G"/>lame shall not <chord root="E" structure="min"/>hurt thee; I <chord root="G"/>only de<chord root="D"/>sign<br/>
+        Thy <chord root="G"/>dross <chord root="C"/>to con<chord root="G"/>sume, <chord root="E" structure="min"/>and thy <chord root="G" bass="D"/>gold <chord root="D" structure="dom7"/>to re<chord root="G"/>fine."
       </lines>
     </verse>
     <verse name="v5">
       <lines>
-        "The <chord name="G"/>soul <chord name="C"/>that on <chord name="G"/>Jesus hath <chord name="G"/>leaned for re<chord name="D"/>pose,<br/>
-        I <chord name="G"/>will <chord name="C"/>not, I <chord name="G"/>will <chord name="Em"/>not de<chord name="G/D"/>sert <chord name="D7"/>to his <chord name="G"/>foes;<br/>
-        That <chord name="G"/>soul, though all <chord name="Em"/>hell should en<chord name="G"/>deavor to <chord name="D"/>shake,<br/>
-        I'll <chord name="G"/>ne<chord name="C"/>ver, no <chord name="G"/>ne<chord name="Em"/>ver, no <chord name="G/D"/>ne<chord name="D7"/>ver for<chord name="G"/>sake!"
+        "The <chord root="G"/>soul <chord root="C"/>that on <chord root="G"/>Jesus hath <chord root="G"/>leaned for re<chord root="D"/>pose,<br/>
+        I <chord root="G"/>will <chord root="C"/>not, I <chord root="G"/>will <chord root="E" structure="min"/>not de<chord root="G" bass="D"/>sert <chord root="D" structure="dom7"/>to his <chord root="G"/>foes;<br/>
+        That <chord root="G"/>soul, though all <chord root="E" structure="min"/>hell should en<chord root="G"/>deavor to <chord root="D"/>shake,<br/>
+        I'll <chord root="G"/>ne<chord root="C"/>ver, no <chord root="G"/>ne<chord root="E" structure="min"/>ver, no <chord root="G" bass="D"/>ne<chord root="D" structure="dom7"/>ver for<chord root="G"/>sake!"
       </lines>
     </verse>
   </lyrics>

--- a/songs/How Great Thou Art.xml
+++ b/songs/How Great Thou Art.xml
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../stylesheets/openlyrics.css" type="text/css"?>
-<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.8" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:49.359318">
+<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.9" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:49.359318">
   <properties>
     <titles>
       <title>How Great Thou Art</title>
@@ -13,42 +13,42 @@
   <lyrics>
     <verse name="v1">
       <lines>
-        Oh Lord my <chord name="A2"/>God, when I in <chord name="D"/>awesome wonder<br/>
-        Consider <chord name="A2"/>all the <chord name="E"/>worlds Thy <chord name="Bm"/>hands have <chord name="A2"/>made;<br/>
-        I see the stars, I hear the <chord name="D"/>rolling thunder:<br/>
-        Thy pow'r through<chord name="A2"/>out the  <chord name="E"/>uni<chord name="Bm"/>verse dis<chord name="A2"/>played.
+        Oh Lord my <chord root="A" structure="add9"/>God, when I in <chord root="D"/>awesome wonder<br/>
+        Consider <chord root="A" structure="add9"/>all the <chord root="E"/>worlds Thy <chord root="B" structure="min"/>hands have <chord root="A" structure="add9"/>made;<br/>
+        I see the stars, I hear the <chord root="D"/>rolling thunder:<br/>
+        Thy pow'r through<chord root="A" structure="add9"/>out the <chord root="E"/>uni<chord root="B" structure="min"/>verse dis<chord root="A" structure="add9"/>played.
       </lines>
     </verse>
     <verse name="v2">
       <lines>
-        When through the <chord name="A2"/>woods, and forest <chord name="D"/>glades I wander,<br/>
-        And hear the <chord name="A2"/>birds sing <chord name="E"/>sweetly <chord name="Bm"/>in the <chord name="A2"/>trees;<br/>
-        When I look down from lofty <chord name="D"/>mountain grandeur,<br/>
-        And hear the b<chord name="A2"/>rook and <chord name="E"/>feel the <chord name="Bm"/>gentle <chord name="A2"/>breeze.
+        When through the <chord root="A" structure="add9"/>woods, and forest <chord root="D"/>glades I wander,<br/>
+        And hear the <chord root="A" structure="add9"/>birds sing <chord root="E"/>sweetly <chord root="B" structure="min"/>in the <chord root="A" structure="add9"/>trees;<br/>
+        When I look down from lofty <chord root="D"/>mountain grandeur,<br/>
+        And hear the b<chord root="A" structure="add9"/>rook and <chord root="E"/>feel the <chord root="B" structure="min"/>gentle <chord root="A" structure="add9"/>breeze.
       </lines>
     </verse>
     <verse name="v3">
       <lines>
-        And when I <chord name="A2"/>think that God, His <chord name="D"/>Son not sparing<br/>
-        Sent Him to <chord name="A2"/>die, I <chord name="E"/>scarce can <chord name="Bm"/>take it <chord name="A2"/>in;<br/>
-        That on the cross, my burden <chord name="D"/>gladly bearing,<br/>
-        He bled and d<chord name="A2"/>ied to <chord name="E"/>take a<chord name="Bm"/>way my <chord name="A2"/>sin.
+        And when I <chord root="A" structure="add9"/>think that God, His <chord root="D"/>Son not sparing<br/>
+        Sent Him to <chord root="A" structure="add9"/>die, I <chord root="E"/>scarce can <chord root="B" structure="min"/>take it <chord root="A" structure="add9"/>in;<br/>
+        That on the cross, my burden <chord root="D"/>gladly bearing,<br/>
+        He bled and d<chord root="A" structure="add9"/>ied to <chord root="E"/>take a<chord root="B" structure="min"/>way my <chord root="A" structure="add9"/>sin.
       </lines>
     </verse>
     <verse name="v4">
       <lines>
-        When Christ shall <chord name="A2"/>come with shout of <chord name="D"/>acclamation<br/>
-        And take me <chord name="A2"/>home, what <chord name="E"/>joy shall <chord name="Bm"/>fill my <chord name="A2"/>heart;<br/>
-        Then I shall bow in humble <chord name="D"/>adoration,<br/>
-        And there proc<chord name="A2"/>laim my <chord name="E"/>God how <chord name="Bm"/>great Thou <chord name="A2"/>art!
+        When Christ shall <chord root="A" structure="add9"/>come with shout of <chord root="D"/>acclamation<br/>
+        And take me <chord root="A" structure="add9"/>home, what <chord root="E"/>joy shall <chord root="B" structure="min"/>fill my <chord root="A" structure="add9"/>heart;<br/>
+        Then I shall bow in humble <chord root="D"/>adoration,<br/>
+        And there proc<chord root="A" structure="add9"/>laim my <chord root="E"/>God how <chord root="B" structure="min"/>great Thou <chord root="A" structure="add9"/>art!
       </lines>
     </verse>
     <verse name="c">
       <lines>
-        Then sings my <chord name="A2"/>soul my <chord name="D"/>Savior God to <chord name="A2"/>Thee,<br/>
-        How great Thou <chord name="E"/>art, how great Thou <chord name="A2"/>art;<br/>
-        Then sings my soul my <chord name="D"/>Savior God to <chord name="A2"/>Thee,<br/>
-        How great Thou <chord name="E"/>art<chord name="Bm"/>, how great Thou <chord name="A2"/>art.
+        Then sings my <chord root="A" structure="add9"/>soul my <chord root="D"/>Savior God to <chord root="A" structure="add9"/>Thee,<br/>
+        How great Thou <chord root="E"/>art, how great Thou <chord root="A" structure="add9"/>art;<br/>
+        Then sings my soul my <chord root="D"/>Savior God to <chord root="A" structure="add9"/>Thee,<br/>
+        How great Thou <chord root="E"/>art<chord root="B" structure="min"/>, how great Thou <chord root="A" structure="add9"/>art.
       </lines>
     </verse>
   </lyrics>

--- a/songs/I Have Decided To Follow Jesus.xml
+++ b/songs/I Have Decided To Follow Jesus.xml
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../stylesheets/openlyrics.css" type="text/css"?>
-<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.8" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:49.456276">
+<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.9" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:49.456276">
   <properties>
     <titles>
       <title>I Have Decided To Follow Jesus</title>
@@ -15,26 +15,26 @@
   <lyrics>
     <verse name="v1">
       <lines>
-        I have de<chord name="C"/>ci<chord name="Em/B"/>ded<chord name="Am"/> to follow <chord name="C"/>Jesus,<br/>
-        I have de<chord name="F"/>ci<chord name="Am/E"/>ded<chord name="F"/> to follow <chord name="C"/>Jesus,<chord name="C/G"/><br/>
-        I have de<chord name="C"/>ci<chord name="Em/B"/>ded<chord name="Am"/> to follow <chord name="C"/>Jesus,<chord name="Am"/><br/>
-        No turning <chord name="C"/>ba<chord name="Am"/>ck,<chord name="G"/> no turning <chord name="C"/>back.
+        I have de<chord root="C"/>ci<chord root="E" structure="min" bass="B"/>ded<chord root="A" structure="min"/> to follow <chord root="C"/>Jesus,<br/>
+        I have de<chord root="F"/>ci<chord root="A" structure="min" bass="E"/>ded<chord root="F"/> to follow <chord root="C"/>Jesus,<chord root="C" bass="G"/><br/>
+        I have de<chord root="C"/>ci<chord root="E" structure="min" bass="B"/>ded<chord root="A" structure="min"/> to follow <chord root="C"/>Jesus,<chord root="A" structure="min"/><br/>
+        No turning <chord root="C"/>ba<chord root="A" structure="min"/>ck,<chord root="G"/> no turning <chord root="C"/>back.
       </lines>
     </verse>
     <verse name="v2">
       <lines>
-        The world be<chord name="C"/>hind <chord name="Em/B"/>me,<chord name="Am"/> the cross be<chord name="C"/>fore me,<br/>
-        The world be<chord name="F"/>hind <chord name="Am/E"/>me,<chord name="F"/> the cross be<chord name="C"/>fore me,<chord name="C/G"/><br/>
-        The world be<chord name="C"/>hind <chord name="Em/B"/>me,<chord name="Am"/> the cross be<chord name="C"/>fore me,<chord name="Am"/><br/>
-        No turning <chord name="C"/>ba<chord name="Am"/>ck,<chord name="G"/> no turning <chord name="C"/>back.
+        The world be<chord root="C"/>hind <chord root="E" structure="min" bass="B"/>me,<chord root="A" structure="min"/> the cross be<chord root="C"/>fore me,<br/>
+        The world be<chord root="F"/>hind <chord root="A" structure="min" bass="E"/>me,<chord root="F"/> the cross be<chord root="C"/>fore me,<chord root="C" bass="G"/><br/>
+        The world be<chord root="C"/>hind <chord root="E" structure="min" bass="B"/>me,<chord root="A" structure="min"/> the cross be<chord root="C"/>fore me,<chord root="A" structure="min"/><br/>
+        No turning <chord root="C"/>ba<chord root="A" structure="min"/>ck,<chord root="G"/> no turning <chord root="C"/>back.
       </lines>
     </verse>
     <verse name="v3">
       <lines>
-        Though none go <chord name="C"/>with <chord name="Em/B"/>me,<chord name="Am"/> still I will <chord name="C"/>follow,<br/>
-        Though none go <chord name="F"/>with <chord name="Am/E"/>me,<chord name="F"/> still I will <chord name="C"/>follow,<chord name="C/G"/><br/>
-        Though none go <chord name="C"/>with <chord name="Em/B"/>me,<chord name="Am"/> still I will <chord name="C"/>follow,<chord name="Am"/><br/>
-        No turning <chord name="C"/>ba<chord name="Am"/>ck,<chord name="G"/> no turning <chord name="C"/>back.
+        Though none go <chord root="C"/>with <chord root="E" structure="min" bass="B"/>me,<chord root="A" structure="min"/> still I will <chord root="C"/>follow,<br/>
+        Though none go <chord root="F"/>with <chord root="A" structure="min" bass="E"/>me,<chord root="F"/> still I will <chord root="C"/>follow,<chord root="C" bass="G"/><br/>
+        Though none go <chord root="C"/>with <chord root="E" structure="min" bass="B"/>me,<chord root="A" structure="min"/> still I will <chord root="C"/>follow,<chord root="A" structure="min"/><br/>
+        No turning <chord root="C"/>ba<chord root="A" structure="min"/>ck,<chord root="G"/> no turning <chord root="C"/>back.
       </lines>
     </verse>
   </lyrics>

--- a/songs/In The Garden.xml
+++ b/songs/In The Garden.xml
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../stylesheets/openlyrics.css" type="text/css"?>
-<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.8" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:49.555644">
+<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.9" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:49.555644">
   <properties>
     <titles>
       <title>In The Garden</title>
@@ -17,28 +17,28 @@
   <lyrics>
     <verse name="v1">
       <lines>
-        I <chord name="G"/>come to the garden alone, While the <chord name="C"/>dew is still on the <chord name="G"/>roses;<br/>
-        And the <chord name="D"/>voice I hear falling <chord name="G"/>on my ear, The <chord name="A7"/>Son of God dis<chord name="D"/>closes.
+        I <chord root="G"/>come to the garden alone, While the <chord root="C"/>dew is still on the <chord root="G"/>roses;<br/>
+        And the <chord root="D"/>voice I hear falling <chord root="G"/>on my ear, The <chord root="A" structure="dom7"/>Son of God dis<chord root="D"/>closes.
       </lines>
     </verse>
     <verse name="c">
       <lines>
-        And He <chord name="G"/>walks with me, and He <chord name="D"/>talks with me,<br/>
-        And He <chord name="C"/>tells me <chord name="D7"/>I am His <chord name="G"/>own;<br/>
-        And the <chord name="G"/>joy we <chord name="B7"/>share as we <chord name="Em"/>tarry <chord name="C"/>there,<br/>
-        None <chord name="G"/>other has <chord name="D7"/>ever <chord name="G"/>known.
+        And He <chord root="G"/>walks with me, and He <chord root="D"/>talks with me,<br/>
+        And He <chord root="C"/>tells me <chord root="D" structure="dom7"/>I am His <chord root="G"/>own;<br/>
+        And the <chord root="G"/>joy we <chord root="B" structure="dom7"/>share as we <chord root="E" structure="min"/>tarry <chord root="C"/>there,<br/>
+        None <chord root="G"/>other has <chord root="D" structure="dom7"/>ever <chord root="G"/>known.
       </lines>
     </verse>
     <verse name="v2">
       <lines>
-        He <chord name="G"/>speaks, and the sound of His voice Is so <chord name="C"/>sweet the birds hush their <chord name="G"/>singing;<br/>
-        And the <chord name="D"/>melody that He <chord name="G"/>gave to me, With<chord name="A7"/>in my heart is <chord name="D"/>ringing.
+        He <chord root="G"/>speaks, and the sound of His voice Is so <chord root="C"/>sweet the birds hush their <chord root="G"/>singing;<br/>
+        And the <chord root="D"/>melody that He <chord root="G"/>gave to me, With<chord root="A" structure="dom7"/>in my heart is <chord root="D"/>ringing.
       </lines>
     </verse>
     <verse name="v3">
       <lines>
-        I'd <chord name="G"/>stay in the garden with Him, Though the <chord name="C"/>night around me be <chord name="G"/>falling;<br/>
-        But He <chord name="D"/>bids me go; thru the <chord name="G"/>voice of woe, His <chord name="A7"/>voice to me is <chord name="D"/>calling.
+        I'd <chord root="G"/>stay in the garden with Him, Though the <chord root="C"/>night around me be <chord root="G"/>falling;<br/>
+        But He <chord root="D"/>bids me go; thru the <chord root="G"/>voice of woe, His <chord root="A" structure="dom7"/>voice to me is <chord root="D"/>calling.
       </lines>
     </verse>
   </lyrics>

--- a/songs/It Is Well With My Soul.xml
+++ b/songs/It Is Well With My Soul.xml
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../stylesheets/openlyrics.css" type="text/css"?>
-<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.8" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:49.643833">
+<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.9" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:49.643833">
   <properties>
     <titles>
       <title>It Is Well With My Soul</title>
@@ -21,41 +21,41 @@
   <lyrics>
     <verse name="v1">
       <lines>
-        When <chord name="C"/>peace like a river at<chord name="F"/>tendeth my <chord name="C"/>way,<br/>
-        When <chord name="Am"/>sorrows like <chord name="D"/>sea billows <chord name="G"/>roll;<br/>
-        What<chord name="C"/>ever my <chord name="F"/>lot, Thou hast <chord name="D"/>taught me to <chord name="G"/>say,<br/>
-        “It is <chord name="C"/>well, it is <chord name="F"/>well <chord name="G"/>with <chord name="C"/>my soul.”
+        When <chord root="C"/>peace like a river at<chord root="F"/>tendeth my <chord root="C"/>way,<br/>
+        When <chord root="A" structure="min"/>sorrows like <chord root="D"/>sea billows <chord root="G"/>roll;<br/>
+        What<chord root="C"/>ever my <chord root="F"/>lot, Thou hast <chord root="D"/>taught me to <chord root="G"/>say,<br/>
+        “It is <chord root="C"/>well, it is <chord root="F"/>well <chord root="G"/>with <chord root="C"/>my soul.”
       </lines>
     </verse>
     <verse name="c">
       <lines>
-        It is <chord name="C"/>well, (it is <chord name="G"/>well,)<br/>
-        With my <chord name="G"/>soul, (with my <chord name="C"/>soul,)<br/>
-        It is <chord name="F"/>well, it is <chord name="C"/>well <chord name="G"/>with my <chord name="C"/>soul.
+        It is <chord root="C"/>well, (it is <chord root="G"/>well,)<br/>
+        With my <chord root="G"/>soul, (with my <chord root="C"/>soul,)<br/>
+        It is <chord root="F"/>well, it is <chord root="C"/>well <chord root="G"/>with my <chord root="C"/>soul.
       </lines>
     </verse>
     <verse name="v2">
       <lines>
-        Though <chord name="C"/>Satan should buffet, though <chord name="F"/>trials should <chord name="C"/>come,<br/>
-        Let <chord name="Am"/>this blest as<chord name="D"/>surance con<chord name="G"/>trol,<br/>
-        That <chord name="C"/>Christ has re<chord name="F"/>garded my <chord name="D"/>helpless e<chord name="G"/>state,<br/>
-        And hath <chord name="C"/>shed his own <chord name="F"/>blood <chord name="G"/>for my <chord name="C"/>soul.
+        Though <chord root="C"/>Satan should buffet, though <chord root="F"/>trials should <chord root="C"/>come,<br/>
+        Let <chord root="A" structure="min"/>this blest as<chord root="D"/>surance con<chord root="G"/>trol,<br/>
+        That <chord root="C"/>Christ has re<chord root="F"/>garded my <chord root="D"/>helpless e<chord root="G"/>state,<br/>
+        And hath <chord root="C"/>shed his own <chord root="F"/>blood <chord root="G"/>for my <chord root="C"/>soul.
       </lines>
     </verse>
     <verse name="v3">
       <lines>
-        My <chord name="C"/>sin, oh the bliss of this <chord name="F"/>glorious <chord name="C"/>thought!<br/>
-        My <chord name="Am"/>sin, not in <chord name="D"/>part but the <chord name="G"/>whole<br/>
-        Is <chord name="C"/>nailed to the <chord name="F"/>cross, and I <chord name="D"/>bear it no <chord name="G"/>more,<br/>
-        Praise the <chord name="C"/>Lord, praise the <chord name="F"/>Lord, <chord name="G"/>O my <chord name="C"/>soul!
+        My <chord root="C"/>sin, oh the bliss of this <chord root="F"/>glorious <chord root="C"/>thought!<br/>
+        My <chord root="A" structure="min"/>sin, not in <chord root="D"/>part but the <chord root="G"/>whole<br/>
+        Is <chord root="C"/>nailed to the <chord root="F"/>cross, and I <chord root="D"/>bear it no <chord root="G"/>more,<br/>
+        Praise the <chord root="C"/>Lord, praise the <chord root="F"/>Lord, <chord root="G"/>O my <chord root="C"/>soul!
       </lines>
     </verse>
     <verse name="v4">
       <lines>
-        And, <chord name="C"/>Lord, haste the day when my <chord name="F"/>faith shall be <chord name="C"/>sight,<br/>
-        The <chord name="Am"/>clouds be rolled <chord name="D"/>back as a <chord name="G"/>scroll;<br/>
-        The <chord name="C"/>trump shall re<chord name="F"/>sound, and the <chord name="D"/>Lord shall de<chord name="G"/>scend,<br/>
-        Even <chord name="C"/>so, it is <chord name="F"/>well <chord name="G"/>with my <chord name="C"/>soul.
+        And, <chord root="C"/>Lord, haste the day when my <chord root="F"/>faith shall be <chord root="C"/>sight,<br/>
+        The <chord root="A" structure="min"/>clouds be rolled <chord root="D"/>back as a <chord root="G"/>scroll;<br/>
+        The <chord root="C"/>trump shall re<chord root="F"/>sound, and the <chord root="D"/>Lord shall de<chord root="G"/>scend,<br/>
+        Even <chord root="C"/>so, it is <chord root="F"/>well <chord root="G"/>with my <chord root="C"/>soul.
       </lines>
     </verse>
   </lyrics>

--- a/songs/Jesus Loves Even Me.xml
+++ b/songs/Jesus Loves Even Me.xml
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../stylesheets/openlyrics.css" type="text/css"?>
-<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.8" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:49.731291">
+<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.9" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:49.731291">
   <properties>
     <titles>
       <title>Jesus Loves Even Me</title>
@@ -15,34 +15,34 @@
   <lyrics>
     <verse name="v1">
       <lines>
-        <chord name="G"/>I am so glad that our Father in heaven<br/>
-        <chord name="D7"/>Tells of His love in the <chord name="C"/>Book He <chord name="D7"/>has <chord name="G"/>given.<br/>
-        <chord name="G"/>Wonderful things in my Bible I see-<br/>
-        <chord name="D7"/>This is the dearest, that <chord name="C"/>Jesus <chord name="D7"/>loves <chord name="G"/>me.
+        <chord root="G"/>I am so glad that our Father in heaven<br/>
+        <chord root="D" structure="dom7"/>Tells of His love in the <chord root="C"/>Book He <chord root="D" structure="dom7"/>has <chord root="G"/>given.<br/>
+        <chord root="G"/>Wonderful things in my Bible I see-<br/>
+        <chord root="D" structure="dom7"/>This is the dearest, that <chord root="C"/>Jesus <chord root="D" structure="dom7"/>loves <chord root="G"/>me.
       </lines>
     </verse>
     <verse name="v2">
       <lines>
-        <chord name="G"/>Tho' I forget Him and wander away,<br/>
-        <chord name="D7"/>Still He doth love me wher<chord name="C"/>ever <chord name="D7"/>I  <chord name="G"/>stray.<br/>
-        <chord name="G"/>Back to His dear, loving arms would I flee<br/>
-        <chord name="D7"/>When I remember that <chord name="C"/>Jesus <chord name="D7"/>loves <chord name="G"/>me.
+        <chord root="G"/>Tho' I forget Him and wander away,<br/>
+        <chord root="D" structure="dom7"/>Still He doth love me wher<chord root="C"/>ever <chord root="D" structure="dom7"/>I <chord root="G"/>stray.<br/>
+        <chord root="G"/>Back to His dear, loving arms would I flee<br/>
+        <chord root="D" structure="dom7"/>When I remember that <chord root="C"/>Jesus <chord root="D" structure="dom7"/>loves <chord root="G"/>me.
       </lines>
     </verse>
     <verse name="v3">
       <lines>
-        <chord name="G"/>O if there's only one song I can sing<br/>
-        <chord name="D7"/>When in His beauty I <chord name="C"/>see the <chord name="D7"/>great <chord name="G"/>King,<br/>
-        <chord name="G"/>This shall my song in eternity be:<br/>
-        <chord name="D7"/>"O what a wonder, that <chord name="C"/>Jesus <chord name="D7"/>loves <chord name="G"/>me!"
+        <chord root="G"/>O if there's only one song I can sing<br/>
+        <chord root="D" structure="dom7"/>When in His beauty I <chord root="C"/>see the <chord root="D" structure="dom7"/>great <chord root="G"/>King,<br/>
+        <chord root="G"/>This shall my song in eternity be:<br/>
+        <chord root="D" structure="dom7"/>"O what a wonder, that <chord root="C"/>Jesus <chord root="D" structure="dom7"/>loves <chord root="G"/>me!"
       </lines>
     </verse>
     <verse name="c">
       <lines>
-        <chord name="G"/>I am so glad that <chord name="C"/>Jesus loves me,<br/>
-        <chord name="D7"/>Jesus loves me, <chord name="G"/>Jesus loves me.<br/>
-        <chord name="G"/>I am so glad that <chord name="C"/>Jesus loves me;<br/>
-        <chord name="D7"/>Jesus loves <chord name="C"/>e<chord name="D"/>ven <chord name="G"/>me.
+        <chord root="G"/>I am so glad that <chord root="C"/>Jesus loves me,<br/>
+        <chord root="D" structure="dom7"/>Jesus loves me, <chord root="G"/>Jesus loves me.<br/>
+        <chord root="G"/>I am so glad that <chord root="C"/>Jesus loves me;<br/>
+        <chord root="D" structure="dom7"/>Jesus loves <chord root="C"/>e<chord root="D"/>ven <chord root="G"/>me.
       </lines>
     </verse>
   </lyrics>

--- a/songs/Leaning On The Everlasting Arms.xml
+++ b/songs/Leaning On The Everlasting Arms.xml
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../stylesheets/openlyrics.css" type="text/css"?>
-<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.8" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:49.819233">
+<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.9" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:49.819233">
   <properties>
     <titles>
       <title>Leaning On The Everlasting Arms</title>
@@ -15,26 +15,26 @@
   <lyrics>
     <verse name="v1">
       <lines>
-        <chord name="G"/>What a fellowship, <chord name="C2"/>what a joy divine! <chord name="G"/>Leaning on the everlasting <chord name="D"/>arms;<br/>
-        <chord name="G"/>What a blessedness, <chord name="C2"/>what a peace is mine! <chord name="G"/>Leaning on the ever<chord name="D"/>lasting <chord name="G"/>arms.
+        <chord root="G"/>What a fellowship, <chord root="C" structure="add9"/>what a joy divine! <chord root="G"/>Leaning on the everlasting <chord root="D"/>arms;<br/>
+        <chord root="G"/>What a blessedness, <chord root="C" structure="add9"/>what a peace is mine! <chord root="G"/>Leaning on the ever<chord root="D"/>lasting <chord root="G"/>arms.
       </lines>
     </verse>
     <verse name="v2">
       <lines>
-        <chord name="G"/>O how sweet to walk <chord name="C2"/>in this pilgrim way, <chord name="G"/>Leaning on the everlasting <chord name="D"/>arms;<br/>
-        <chord name="G"/>O how bright the path <chord name="C2"/>grows from day to day, <chord name="G"/>Leaning on the ever<chord name="D"/>lasting <chord name="G"/>arms.
+        <chord root="G"/>O how sweet to walk <chord root="C" structure="add9"/>in this pilgrim way, <chord root="G"/>Leaning on the everlasting <chord root="D"/>arms;<br/>
+        <chord root="G"/>O how bright the path <chord root="C" structure="add9"/>grows from day to day, <chord root="G"/>Leaning on the ever<chord root="D"/>lasting <chord root="G"/>arms.
       </lines>
     </verse>
     <verse name="v3">
       <lines>
-        <chord name="G"/>What have I do dread? <chord name="C2"/>What have I to fear? <chord name="G"/>Leaning on the everlasting <chord name="D"/>arms;<br/>
-        <chord name="G"/>I have blessed peace <chord name="C2"/>with my Lord so near, <chord name="G"/>Leaning on the ever<chord name="D"/>lasting <chord name="G"/>arms.
+        <chord root="G"/>What have I do dread? <chord root="C" structure="add9"/>What have I to fear? <chord root="G"/>Leaning on the everlasting <chord root="D"/>arms;<br/>
+        <chord root="G"/>I have blessed peace <chord root="C" structure="add9"/>with my Lord so near, <chord root="G"/>Leaning on the ever<chord root="D"/>lasting <chord root="G"/>arms.
       </lines>
     </verse>
     <verse name="c">
       <lines>
-        <chord name="G"/>Leaning, <chord name="C2"/>leaning, <chord name="G"/>Safe and secure from all a<chord name="D"/>larms;<br/>
-        <chord name="G"/>Leaning, <chord name="C2"/>leaning, <chord name="G"/>Leaning on the ever<chord name="D"/>lasting <chord name="G"/>arms.
+        <chord root="G"/>Leaning, <chord root="C" structure="add9"/>leaning, <chord root="G"/>Safe and secure from all a<chord root="D"/>larms;<br/>
+        <chord root="G"/>Leaning, <chord root="C" structure="add9"/>leaning, <chord root="G"/>Leaning on the ever<chord root="D"/>lasting <chord root="G"/>arms.
       </lines>
     </verse>
   </lyrics>

--- a/songs/Man Of Sorrows.xml
+++ b/songs/Man Of Sorrows.xml
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../stylesheets/openlyrics.css" type="text/css"?>
-<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.8" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:49.907069">
+<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.9" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:49.907069">
   <properties>
     <titles>
       <title>Man Of Sorrows</title>
@@ -13,32 +13,32 @@
   <lyrics>
     <verse name="v1">
       <lines>
-        <chord name="A"/>Man of Sorrows, <chord name="F#m"/>what a <chord name="C#"/>name! <chord name="D"/>For the <chord name="A"/>Son of <chord name="E/B"/>God, <chord name="B"/>Who <chord name="E"/>came<br/>
-        <chord name="A"/>Ruined sinners <chord name="D/A"/>to re<chord name="A"/>claim. Hallelu<chord name="E"/>jah! <chord name="F#m"/>What a <chord name="D"/>Sav<chord name="A"/>ior!
+        <chord root="A"/>Man of Sorrows, <chord root="F#" structure="min"/>what a <chord root="C#"/>name! <chord root="D"/>For the <chord root="A"/>Son of <chord root="E" bass="B"/>God, <chord root="B"/>Who <chord root="E"/>came<br/>
+        <chord root="A"/>Ruined sinners <chord root="D" bass="A"/>to re<chord root="A"/>claim. Hallelu<chord root="E"/>jah! <chord root="F#" structure="min"/>What a <chord root="D"/>Sav<chord root="A"/>ior!
       </lines>
     </verse>
     <verse name="v2">
       <lines>
-        <chord name="A"/>Bearing shame and <chord name="F#m"/>scoffing <chord name="C#"/>rude, <chord name="D"/>In my <chord name="A"/>place con<chord name="E/B"/>demne<chord name="B"/>d He<chord name="E"/> stood;<br/>
-        <chord name="A"/>Sealed my pardon <chord name="D/A"/>with His <chord name="A"/>blood. Hallelu<chord name="E"/>jah! <chord name="F#m"/>What a <chord name="D"/>Sav<chord name="A"/>ior!
+        <chord root="A"/>Bearing shame and <chord root="F#" structure="min"/>scoffing <chord root="C#"/>rude, <chord root="D"/>In my <chord root="A"/>place con<chord root="E" bass="B"/>demne<chord root="B"/>d He<chord root="E"/> stood;<br/>
+        <chord root="A"/>Sealed my pardon <chord root="D" bass="A"/>with His <chord root="A"/>blood. Hallelu<chord root="E"/>jah! <chord root="F#" structure="min"/>What a <chord root="D"/>Sav<chord root="A"/>ior!
       </lines>
     </verse>
     <verse name="v3">
       <lines>
-        <chord name="A"/>Guilty, vile, and <chord name="F#m"/>helpless <chord name="C#"/>we; <chord name="D"/>Spotless <chord name="A"/>Lamb of <chord name="E/B"/>God w<chord name="B"/>as H<chord name="E"/>e;<br/>
-        <chord name="A"/>Full atonement! <chord name="D/A"/>Can it <chord name="A"/>be? Hallelu<chord name="E"/>jah! <chord name="F#m"/>What a <chord name="D"/>Sav<chord name="A"/>ior!
+        <chord root="A"/>Guilty, vile, and <chord root="F#" structure="min"/>helpless <chord root="C#"/>we; <chord root="D"/>Spotless <chord root="A"/>Lamb of <chord root="E" bass="B"/>God w<chord root="B"/>as H<chord root="E"/>e;<br/>
+        <chord root="A"/>Full atonement! <chord root="D" bass="A"/>Can it <chord root="A"/>be? Hallelu<chord root="E"/>jah! <chord root="F#" structure="min"/>What a <chord root="D"/>Sav<chord root="A"/>ior!
       </lines>
     </verse>
     <verse name="v4">
       <lines>
-        <chord name="A"/>Lifted up was <chord name="F#m"/>He to <chord name="C#"/>die; <chord name="D"/>"It is <chord name="A"/>finished!" <chord name="E/B"/>was H<chord name="B"/>is c<chord name="E"/>ry;<br/>
-        <chord name="A"/>Now in heaven ex<chord name="D/A"/>alted <chord name="A"/>high. Hallelu<chord name="E"/>jah! <chord name="F#m"/>What a <chord name="D"/>Sav<chord name="A"/>ior!
+        <chord root="A"/>Lifted up was <chord root="F#" structure="min"/>He to <chord root="C#"/>die; <chord root="D"/>"It is <chord root="A"/>finished!" <chord root="E" bass="B"/>was H<chord root="B"/>is c<chord root="E"/>ry;<br/>
+        <chord root="A"/>Now in heaven ex<chord root="D" bass="A"/>alted <chord root="A"/>high. Hallelu<chord root="E"/>jah! <chord root="F#" structure="min"/>What a <chord root="D"/>Sav<chord root="A"/>ior!
       </lines>
     </verse>
     <verse name="v5">
       <lines>
-        <chord name="A"/>When He comes, our <chord name="F#m"/>glorious <chord name="C#"/>King, <chord name="D"/>All His <chord name="A"/>ransomed <chord name="E/B"/>home <chord name="B"/>to b<chord name="E"/>ring,<br/>
-        <chord name="A"/>Then anew His <chord name="D/A"/>song we’ll <chord name="A"/>sing: Hallelu<chord name="E"/>jah! <chord name="F#m"/>What a <chord name="D"/>Sav<chord name="A"/>ior!
+        <chord root="A"/>When He comes, our <chord root="F#" structure="min"/>glorious <chord root="C#"/>King, <chord root="D"/>All His <chord root="A"/>ransomed <chord root="E" bass="B"/>home <chord root="B"/>to b<chord root="E"/>ring,<br/>
+        <chord root="A"/>Then anew His <chord root="D" bass="A"/>song we’ll <chord root="A"/>sing: Hallelu<chord root="E"/>jah! <chord root="F#" structure="min"/>What a <chord root="D"/>Sav<chord root="A"/>ior!
       </lines>
     </verse>
   </lyrics>

--- a/songs/Nothing But The Blood.xml
+++ b/songs/Nothing But The Blood.xml
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../stylesheets/openlyrics.css" type="text/css"?>
-<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.8" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:49.994428">
+<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.9" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:49.994428">
   <properties>
     <titles>
       <title>Nothing But The Blood</title>
@@ -18,28 +18,28 @@
   <lyrics>
     <verse name="v1">
       <lines>
-        <chord name="E"/>What can wash a<chord name="C#m7"/>way my sin? <chord name="A2"/>Nothing but the blood of <chord name="Bsus"/>Je<chord name="E"/>sus;<br/>
-        <chord name="E"/>What can make me <chord name="C#m7"/>whole again? <chord name="A2"/>Nothing but the blood of <chord name="Bsus"/>Je<chord name="E"/>sus.
+        <chord root="E"/>What can wash a<chord root="C#" structure="min7"/>way my sin? <chord root="A" structure="add9"/>Nothing but the blood of <chord root="B" structure="sus4"/>Je<chord root="E"/>sus;<br/>
+        <chord root="E"/>What can make me <chord root="C#" structure="min7"/>whole again? <chord root="A" structure="add9"/>Nothing but the blood of <chord root="B" structure="sus4"/>Je<chord root="E"/>sus.
       </lines>
     </verse>
     <verse name="c">
       <lines>
-        <chord name="E"/>Oh precious <chord name="C#m7"/>is the flow,<br/>
-        <chord name="Bsus"/>That makes me white as snow;<br/>
-        <chord name="E"/>No other <chord name="C#m7"/>fount I know,<br/>
-        <chord name="A2"/>Nothing but the blood of <chord name="Bsus"/>Je<chord name="E"/>sus.
+        <chord root="E"/>Oh precious <chord root="C#" structure="min7"/>is the flow,<br/>
+        <chord root="B" structure="sus4"/>That makes me white as snow;<br/>
+        <chord root="E"/>No other <chord root="C#" structure="min7"/>fount I know,<br/>
+        <chord root="A" structure="add9"/>Nothing but the blood of <chord root="B" structure="sus4"/>Je<chord root="E"/>sus.
       </lines>
     </verse>
     <verse name="v2">
       <lines>
-        <chord name="E"/>For my pardon <chord name="C#m7"/>this I see, <chord name="A2"/>nothing but the blood of <chord name="Bsus"/>Je<chord name="E"/>sus;<br/>
-        <chord name="E"/>For my cleansing <chord name="C#m7"/>this my plea, <chord name="A2"/>nothing but the blood of <chord name="Bsus"/>Je<chord name="E"/>sus.
+        <chord root="E"/>For my pardon <chord root="C#" structure="min7"/>this I see, <chord root="A" structure="add9"/>nothing but the blood of <chord root="B" structure="sus4"/>Je<chord root="E"/>sus;<br/>
+        <chord root="E"/>For my cleansing <chord root="C#" structure="min7"/>this my plea, <chord root="A" structure="add9"/>nothing but the blood of <chord root="B" structure="sus4"/>Je<chord root="E"/>sus.
       </lines>
     </verse>
     <verse name="v3">
       <lines>
-        <chord name="E"/>This is all my <chord name="C#m7"/>hope and peace, <chord name="A2"/>nothing but the blood of <chord name="Bsus"/>Je<chord name="E"/>sus;<br/>
-        <chord name="E"/>This is all my <chord name="C#m7"/>righteousness, <chord name="A2"/>nothing but the blood of <chord name="Bsus"/>Je<chord name="E"/>sus.
+        <chord root="E"/>This is all my <chord root="C#" structure="min7"/>hope and peace, <chord root="A" structure="add9"/>nothing but the blood of <chord root="B" structure="sus4"/>Je<chord root="E"/>sus;<br/>
+        <chord root="E"/>This is all my <chord root="C#" structure="min7"/>righteousness, <chord root="A" structure="add9"/>nothing but the blood of <chord root="B" structure="sus4"/>Je<chord root="E"/>sus.
       </lines>
     </verse>
   </lyrics>

--- a/songs/Since I Have Been Redeemed.xml
+++ b/songs/Since I Have Been Redeemed.xml
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../stylesheets/openlyrics.css" type="text/css"?>
-<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.8" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:50.087250">
+<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.9" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:50.087250">
   <properties>
     <titles>
       <title>Since I Have Been Redeemed</title>
@@ -16,32 +16,32 @@
   <lyrics>
     <verse name="v1">
       <lines>
-        I <chord name="D"/>have a song I <chord name="A"/>love to <chord name="D"/>sing, since I have been re<chord name="A"/>deemed;<br/>
-        Of <chord name="D"/>my Redeemer, <chord name="A"/>Savior, <chord name="D"/>King, since <chord name="G"/>I have <chord name="A"/>been re<chord name="D"/>deemed.
+        I <chord root="D"/>have a song I <chord root="A"/>love to <chord root="D"/>sing, since I have been re<chord root="A"/>deemed;<br/>
+        Of <chord root="D"/>my Redeemer, <chord root="A"/>Savior, <chord root="D"/>King, since <chord root="G"/>I have <chord root="A"/>been re<chord root="D"/>deemed.
       </lines>
     </verse>
     <verse name="c">
       <lines>
-        Since <chord name="D"/>I have been re<chord name="A"/>deemed, since <chord name="G"/>I have been redeemed I will <chord name="D"/>glory <chord name="A"/>in His <chord name="D"/>name;<br/>
-        Since <chord name="D"/>I have been re<chord name="A"/>deemed, I will <chord name="G"/>glory in my <chord name="A"/>Savior’s <chord name="D"/>name.
+        Since <chord root="D"/>I have been re<chord root="A"/>deemed, since <chord root="G"/>I have been redeemed I will <chord root="D"/>glory <chord root="A"/>in His <chord root="D"/>name;<br/>
+        Since <chord root="D"/>I have been re<chord root="A"/>deemed, I will <chord root="G"/>glory in my <chord root="A"/>Savior’s <chord root="D"/>name.
       </lines>
     </verse>
     <verse name="v2">
       <lines>
-        I <chord name="D"/>have a Christ Who <chord name="A"/>satis<chord name="D"/>fies, since I have been re<chord name="A"/>deemed;<br/>
-        To <chord name="D"/>do His will my <chord name="A"/>highest <chord name="D"/>prize, since <chord name="G"/>I have <chord name="A"/>been re<chord name="D"/>deemed.
+        I <chord root="D"/>have a Christ Who <chord root="A"/>satis<chord root="D"/>fies, since I have been re<chord root="A"/>deemed;<br/>
+        To <chord root="D"/>do His will my <chord root="A"/>highest <chord root="D"/>prize, since <chord root="G"/>I have <chord root="A"/>been re<chord root="D"/>deemed.
       </lines>
     </verse>
     <verse name="v3">
       <lines>
-        I <chord name="D"/>have a witness <chord name="A"/>bright and <chord name="D"/>clear, since I have been re<chord name="A"/>deemed;<br/>
-        Dis<chord name="D"/>pelling every <chord name="A"/>doubt and <chord name="D"/>fear, since <chord name="G"/>I have <chord name="A"/>been re<chord name="D"/>deemed.
+        I <chord root="D"/>have a witness <chord root="A"/>bright and <chord root="D"/>clear, since I have been re<chord root="A"/>deemed;<br/>
+        Dis<chord root="D"/>pelling every <chord root="A"/>doubt and <chord root="D"/>fear, since <chord root="G"/>I have <chord root="A"/>been re<chord root="D"/>deemed.
       </lines>
     </verse>
     <verse name="v4">
       <lines>
-        I <chord name="D"/>have a home pre<chord name="A"/>pared for <chord name="D"/>me, since I have been re<chord name="A"/>deemed;<br/>
-        Where <chord name="D"/>I shall dwell e<chord name="A"/>ternal<chord name="D"/>ly, since <chord name="G"/>I have <chord name="A"/>been re<chord name="D"/>deemed.
+        I <chord root="D"/>have a home pre<chord root="A"/>pared for <chord root="D"/>me, since I have been re<chord root="A"/>deemed;<br/>
+        Where <chord root="D"/>I shall dwell e<chord root="A"/>ternal<chord root="D"/>ly, since <chord root="G"/>I have <chord root="A"/>been re<chord root="D"/>deemed.
       </lines>
     </verse>
   </lyrics>

--- a/songs/Standing On The Promises.xml
+++ b/songs/Standing On The Promises.xml
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../stylesheets/openlyrics.css" type="text/css"?>
-<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.8" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:50.175271">
+<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.9" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:50.175271">
   <properties>
     <titles>
       <title>Standing On The Promises</title>
@@ -20,50 +20,50 @@
   <lyrics>
     <verse name="v1">
       <lines>
-        <chord name="G"/>Standing on the promises of Christ, my King!<br/>
-        <chord name="C"/>Through eternal ages let His <chord name="G"/>praises ring;<br/>
-        <chord name="G"/>"Glory in the highest!" I will shout and sing,<br/>
-        Standing on the <chord name="Am"/>promi<chord name="D"/>ses of <chord name="G"/>God.
+        <chord root="G"/>Standing on the promises of Christ, my King!<br/>
+        <chord root="C"/>Through eternal ages let His <chord root="G"/>praises ring;<br/>
+        <chord root="G"/>"Glory in the highest!" I will shout and sing,<br/>
+        Standing on the <chord root="A" structure="min"/>promi<chord root="D"/>ses of <chord root="G"/>God.
       </lines>
     </verse>
     <verse name="v2">
       <lines>
-        <chord name="G"/>Standing on the promises that cannot fail,<br/>
-        <chord name="C"/>When the howling storms of doubt and <chord name="G"/>fears assail,<br/>
-        <chord name="G"/>By the living Word of God I shall prevail,<br/>
-        Standing on the <chord name="Am"/>promi<chord name="D"/>ses of <chord name="G"/>God.
+        <chord root="G"/>Standing on the promises that cannot fail,<br/>
+        <chord root="C"/>When the howling storms of doubt and <chord root="G"/>fears assail,<br/>
+        <chord root="G"/>By the living Word of God I shall prevail,<br/>
+        Standing on the <chord root="A" structure="min"/>promi<chord root="D"/>ses of <chord root="G"/>God.
       </lines>
     </verse>
     <verse name="v3">
       <lines>
-        <chord name="G"/>Standing on the promises, I now can see<br/>
-        <chord name="C"/>Perfect, present cleansing in the <chord name="G"/>blood for me;<br/>
-        <chord name="G"/>Standing in the liberty where Christ makes free,<br/>
-        Standing on the <chord name="Am"/>promi<chord name="D"/>ses of <chord name="G"/>God.
+        <chord root="G"/>Standing on the promises, I now can see<br/>
+        <chord root="C"/>Perfect, present cleansing in the <chord root="G"/>blood for me;<br/>
+        <chord root="G"/>Standing in the liberty where Christ makes free,<br/>
+        Standing on the <chord root="A" structure="min"/>promi<chord root="D"/>ses of <chord root="G"/>God.
       </lines>
     </verse>
     <verse name="v4">
       <lines>
-        <chord name="G"/>Standing on the promises of Christ the Lord,<br/>
-        <chord name="C"/>Bound to Him eternally by <chord name="G"/>love's strong cord,<br/>
-        <chord name="G"/>Overcoming daily with the Spirit's sword,<br/>
-        Standing on the <chord name="Am"/>promi<chord name="D"/>ses of <chord name="G"/>God.
+        <chord root="G"/>Standing on the promises of Christ the Lord,<br/>
+        <chord root="C"/>Bound to Him eternally by <chord root="G"/>love's strong cord,<br/>
+        <chord root="G"/>Overcoming daily with the Spirit's sword,<br/>
+        Standing on the <chord root="A" structure="min"/>promi<chord root="D"/>ses of <chord root="G"/>God.
       </lines>
     </verse>
     <verse name="v5">
       <lines>
-        <chord name="G"/>Standing on the promises, I cannot fall,<br/>
-        <chord name="C"/>List'ning every moment to the <chord name="G"/>Spirit's call,<br/>
-        <chord name="G"/>Resting in my Saviour as my All-in-All,<br/>
-        Standing on the <chord name="Am"/>promi<chord name="D"/>ses of <chord name="G"/>God.
+        <chord root="G"/>Standing on the promises, I cannot fall,<br/>
+        <chord root="C"/>List'ning every moment to the <chord root="G"/>Spirit's call,<br/>
+        <chord root="G"/>Resting in my Saviour as my All-in-All,<br/>
+        Standing on the <chord root="A" structure="min"/>promi<chord root="D"/>ses of <chord root="G"/>God.
       </lines>
     </verse>
     <verse name="c">
       <lines>
-        <chord name="G"/>Standing, <chord name="C"/>stan<chord name="Em"/>ding,<br/>
-        <chord name="D"/>Standing on the promises of <chord name="G"/>Christ my <chord name="C"/>Sav<chord name="G"/>iour;<br/>
-        Standing, <chord name="C"/>standing<br/>
-        I'm <chord name="G"/>standing on the <chord name="Dsus"/>promi<chord name="D"/>ses of <chord name="G"/>God.
+        <chord root="G"/>Standing, <chord root="C"/>stan<chord root="E" structure="min"/>ding,<br/>
+        <chord root="D"/>Standing on the promises of <chord root="G"/>Christ my <chord root="C"/>Sav<chord root="G"/>iour;<br/>
+        Standing, <chord root="C"/>standing<br/>
+        I'm <chord root="G"/>standing on the <chord root="D" structure="sus4"/>promi<chord root="D"/>ses of <chord root="G"/>God.
       </lines>
     </verse>
   </lyrics>

--- a/songs/The Old Rugged Cross.xml
+++ b/songs/The Old Rugged Cross.xml
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../stylesheets/openlyrics.css" type="text/css"?>
-<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.8" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:50.263187">
+<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.9" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:50.263187">
   <properties>
     <titles>
       <title>The Old Rugged Cross</title>
@@ -17,34 +17,34 @@
   <lyrics>
     <verse name="v1">
       <lines>
-        On a <chord name="A"/>hill far away stood an <chord name="D"/>old rugged cross, The <chord name="E7"/>emblem of suff'ring and <chord name="A"/>shame;<br/>
-        And I <chord name="A"/>love that old cross where the <chord name="D"/>dearest and best, For a <chord name="E7"/>world of lost sinners was <chord name="A"/>slain.
+        On a <chord root="A"/>hill far away stood an <chord root="D"/>old rugged cross, The <chord root="E" structure="dom7"/>emblem of suff'ring and <chord root="A"/>shame;<br/>
+        And I <chord root="A"/>love that old cross where the <chord root="D"/>dearest and best, For a <chord root="E" structure="dom7"/>world of lost sinners was <chord root="A"/>slain.
       </lines>
     </verse>
     <verse name="c">
       <lines>
-        So I'll <chord name="E7"/>cherish the old rugged <chord name="A"/>cross,<br/>
-        Till my <chord name="D"/>trophies at last I lay <chord name="A"/>down;<br/>
-        I will <chord name="A"/>cling to the old rugged <chord name="D"/>cross,<br/>
-        And ex<chord name="A"/>change it some <chord name="E7"/>day for a <chord name="A"/>crown.
+        So I'll <chord root="E" structure="dom7"/>cherish the old rugged <chord root="A"/>cross,<br/>
+        Till my <chord root="D"/>trophies at last I lay <chord root="A"/>down;<br/>
+        I will <chord root="A"/>cling to the old rugged <chord root="D"/>cross,<br/>
+        And ex<chord root="A"/>change it some <chord root="E" structure="dom7"/>day for a <chord root="A"/>crown.
       </lines>
     </verse>
     <verse name="v2">
       <lines>
-        Oh that <chord name="A"/>old rugged cross, so de<chord name="D"/>spised by the world, Has a <chord name="E7"/>wondrous attraction for <chord name="A"/>me;<br/>
-        For the <chord name="A"/>dear Lamb of God left His <chord name="A"/>glory above, To <chord name="E7"/>bear it to dark Calva<chord name="A"/>ry.
+        Oh that <chord root="A"/>old rugged cross, so de<chord root="D"/>spised by the world, Has a <chord root="E" structure="dom7"/>wondrous attraction for <chord root="A"/>me;<br/>
+        For the <chord root="A"/>dear Lamb of God left His <chord root="A"/>glory above, To <chord root="E" structure="dom7"/>bear it to dark Calva<chord root="A"/>ry.
       </lines>
     </verse>
     <verse name="v3">
       <lines>
-        In the <chord name="A"/>old rugged cross, stained with <chord name="D"/>blood so divine, A <chord name="E7"/>wondrous beauty I <chord name="A"/>see;<br/>
-        For twas <chord name="A"/>on that old cross Jesus <chord name="D"/>suffered and died, To <chord name="E7"/>pardon and sanctify <chord name="A"/>me.
+        In the <chord root="A"/>old rugged cross, stained with <chord root="D"/>blood so divine, A <chord root="E" structure="dom7"/>wondrous beauty I <chord root="A"/>see;<br/>
+        For twas <chord root="A"/>on that old cross Jesus <chord root="D"/>suffered and died, To <chord root="E" structure="dom7"/>pardon and sanctify <chord root="A"/>me.
       </lines>
     </verse>
     <verse name="v4">
       <lines>
-        To the <chord name="A"/>old rugged cross I will <chord name="D"/>ever be true, Its <chord name="E7"/>shame and reproach gladly <chord name="A"/>bear;<br/>
-        Then He'll <chord name="A"/>call me some day to my <chord name="D"/>home far away, Where his <chord name="E7"/>glory forever I'll <chord name="A"/>share.
+        To the <chord root="A"/>old rugged cross I will <chord root="D"/>ever be true, Its <chord root="E" structure="dom7"/>shame and reproach gladly <chord root="A"/>bear;<br/>
+        Then He'll <chord root="A"/>call me some day to my <chord root="D"/>home far away, Where his <chord root="E" structure="dom7"/>glory forever I'll <chord root="A"/>share.
       </lines>
     </verse>
   </lyrics>

--- a/songs/The Solid Rock.xml
+++ b/songs/The Solid Rock.xml
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../stylesheets/openlyrics.css" type="text/css"?>
-<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.8" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:50.351916">
+<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.9" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:50.351916">
   <properties>
     <titles>
       <title>The Solid Rock</title>
@@ -16,33 +16,33 @@
   <lyrics>
     <verse name="v1">
       <lines>
-        My <chord name="E"/>hope is built on <chord name="B"/>nothing less than <chord name="A"/>Jesus' blood and <chord name="B"/>righteous<chord name="E"/>ness;<br/>
-        I <chord name="E"/>dare not trust the <chord name="B"/>sweetest frame, but <chord name="A"/>wholly lean on <chord name="B"/>Jesus' <chord name="E"/>name.
+        My <chord root="E"/>hope is built on <chord root="B"/>nothing less than <chord root="A"/>Jesus' blood and <chord root="B"/>righteous<chord root="E"/>ness;<br/>
+        I <chord root="E"/>dare not trust the <chord root="B"/>sweetest frame, but <chord root="A"/>wholly lean on <chord root="B"/>Jesus' <chord root="E"/>name.
       </lines>
     </verse>
     <verse name="v2">
       <lines>
-        When <chord name="E"/>darkness veils His <chord name="B"/>lovely face, I <chord name="A"/>rest on His un<chord name="B"/>changing <chord name="E"/>grace.<br/>
-        In <chord name="E"/>every high and <chord name="B"/>stormy gale, my <chord name="A"/>anchor holds with<chord name="B"/>in the <chord name="E"/>veil.
+        When <chord root="E"/>darkness veils His <chord root="B"/>lovely face, I <chord root="A"/>rest on His un<chord root="B"/>changing <chord root="E"/>grace.<br/>
+        In <chord root="E"/>every high and <chord root="B"/>stormy gale, my <chord root="A"/>anchor holds with<chord root="B"/>in the <chord root="E"/>veil.
       </lines>
     </verse>
     <verse name="v3">
       <lines>
-        His  <chord name="E"/>oath, His cove<chord name="B"/>nant, His blood sup<chord name="A"/>port me in the <chord name="B"/>whelming <chord name="E"/>flood;<br/>
-        When <chord name="E"/>all around my <chord name="B"/>soul gives way, He <chord name="A"/>then is all my <chord name="B"/>hope and <chord name="E"/>stay.
+        His <chord root="E"/>oath, His cove<chord root="B"/>nant, His blood sup<chord root="A"/>port me in the <chord root="B"/>whelming <chord root="E"/>flood;<br/>
+        When <chord root="E"/>all around my <chord root="B"/>soul gives way, He <chord root="A"/>then is all my <chord root="B"/>hope and <chord root="E"/>stay.
       </lines>
     </verse>
     <verse name="v4">
       <lines>
-        When <chord name="E"/>He shall come with <chord name="B"/>trumpet sound, O <chord name="A"/>may I then in <chord name="B"/>Him be <chord name="E"/>found;<br/>
-        Dressed <chord name="E"/>in His righteous<chord name="B"/>ness alone, fault<chord name="A"/>less to stand be<chord name="B"/>fore the <chord name="E"/>throne.
+        When <chord root="E"/>He shall come with <chord root="B"/>trumpet sound, O <chord root="A"/>may I then in <chord root="B"/>Him be <chord root="E"/>found;<br/>
+        Dressed <chord root="E"/>in His righteous<chord root="B"/>ness alone, fault<chord root="A"/>less to stand be<chord root="B"/>fore the <chord root="E"/>throne.
       </lines>
     </verse>
     <verse name="c">
       <lines>
-        On <chord name="E"/>Christ, the solid <chord name="A"/>rock I stand;<br/>
-        All <chord name="E"/>other ground is sinking <chord name="B"/>sand,<br/>
-        All <chord name="A"/>other ground is <chord name="B"/>sinking <chord name="E"/>sand.
+        On <chord root="E"/>Christ, the solid <chord root="A"/>rock I stand;<br/>
+        All <chord root="E"/>other ground is sinking <chord root="B"/>sand,<br/>
+        All <chord root="A"/>other ground is <chord root="B"/>sinking <chord root="E"/>sand.
       </lines>
     </verse>
   </lyrics>

--- a/songs/What A Friend We Have In Jesus.xml
+++ b/songs/What A Friend We Have In Jesus.xml
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../stylesheets/openlyrics.css" type="text/css"?>
-<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.8" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:50.438967">
+<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.9" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:50.438967">
   <properties>
     <titles>
       <title>What A Friend We Have In Jesus</title>
@@ -20,26 +20,26 @@
   <lyrics>
     <verse name="v1">
       <lines>
-        <chord name="D"/>What a friend we have in <chord name="G"/>Jesus, <chord name="D"/>All ours sins and griefs to <chord name="A"/>bear;<br/>
-        <chord name="D"/>What a privilege to <chord name="G"/>carry, <chord name="A"/>Everything to God in <chord name="D"/>prayer!<br/>
-        <chord name="A"/>O what peace we often <chord name="D"/>forfeit, <chord name="G"/>O what <chord name="D"/>needless pain we <chord name="A"/>bear;<br/>
-        <chord name="D"/>All because we do not <chord name="G"/>carry, <chord name="A"/>Everything to God in <chord name="D"/>prayer!
+        <chord root="D"/>What a friend we have in <chord root="G"/>Jesus, <chord root="D"/>All ours sins and griefs to <chord root="A"/>bear;<br/>
+        <chord root="D"/>What a privilege to <chord root="G"/>carry, <chord root="A"/>Everything to God in <chord root="D"/>prayer!<br/>
+        <chord root="A"/>O what peace we often <chord root="D"/>forfeit, <chord root="G"/>O what <chord root="D"/>needless pain we <chord root="A"/>bear;<br/>
+        <chord root="D"/>All because we do not <chord root="G"/>carry, <chord root="A"/>Everything to God in <chord root="D"/>prayer!
       </lines>
     </verse>
     <verse name="v2">
       <lines>
-        <chord name="D"/>Have we trials and temp<chord name="G"/>tations? <chord name="D"/>Is there trouble any<chord name="A"/>where?<br/>
-        <chord name="D"/>We should never be dis<chord name="G"/>couraged, <chord name="A"/>Take it to the Lord in <chord name="D"/>prayer.<br/>
-        <chord name="A"/>Can we find a friend so <chord name="D"/>faithful? <chord name="G"/>Who will <chord name="D"/>all our sorrows <chord name="A"/>share?<br/>
-        <chord name="D"/>Jesus knows our every <chord name="G"/>weakness; <chord name="A"/>Take it to the Lord in <chord name="D"/>prayer.
+        <chord root="D"/>Have we trials and temp<chord root="G"/>tations? <chord root="D"/>Is there trouble any<chord root="A"/>where?<br/>
+        <chord root="D"/>We should never be dis<chord root="G"/>couraged, <chord root="A"/>Take it to the Lord in <chord root="D"/>prayer.<br/>
+        <chord root="A"/>Can we find a friend so <chord root="D"/>faithful? <chord root="G"/>Who will <chord root="D"/>all our sorrows <chord root="A"/>share?<br/>
+        <chord root="D"/>Jesus knows our every <chord root="G"/>weakness; <chord root="A"/>Take it to the Lord in <chord root="D"/>prayer.
       </lines>
     </verse>
     <verse name="v3">
       <lines>
-        <chord name="D"/>Are we weak and heavy <chord name="G"/>laden, <chord name="D"/>Cumbered with a load of <chord name="A"/>care?<br/>
-        <chord name="D"/>Precious Saviour still our <chord name="G"/>refuge; <chord name="A"/>Take it to the Lord in <chord name="D"/>prayer.<br/>
-        <chord name="A"/>Do thy friends despise for<chord name="D"/>sake thee? <chord name="G"/>Take it <chord name="D"/>to the Lord in <chord name="A"/>prayer!<br/>
-        <chord name="D"/>In His arms He’ll take and <chord name="G"/>shield thee; <chord name="A"/>Thou wilt find a solace <chord name="D"/>there.
+        <chord root="D"/>Are we weak and heavy <chord root="G"/>laden, <chord root="D"/>Cumbered with a load of <chord root="A"/>care?<br/>
+        <chord root="D"/>Precious Saviour still our <chord root="G"/>refuge; <chord root="A"/>Take it to the Lord in <chord root="D"/>prayer.<br/>
+        <chord root="A"/>Do thy friends despise for<chord root="D"/>sake thee? <chord root="G"/>Take it <chord root="D"/>to the Lord in <chord root="A"/>prayer!<br/>
+        <chord root="D"/>In His arms He’ll take and <chord root="G"/>shield thee; <chord root="A"/>Thou wilt find a solace <chord root="D"/>there.
       </lines>
     </verse>
   </lyrics>

--- a/songs/When We All Get To Heaven.xml
+++ b/songs/When We All Get To Heaven.xml
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../stylesheets/openlyrics.css" type="text/css"?>
-<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.8" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:50.527427">
+<song xmlns="http://openlyrics.info/namespace/2009/song" version="0.9" createdIn="opensong2openlyrics.py 0.3" modifiedIn="convert-schema.py" modifiedDate="2012-04-10T21:31:50.527427">
   <properties>
     <titles>
       <title>When We All Get To Heaven</title>
@@ -20,32 +20,32 @@
   <lyrics>
     <verse name="v1">
       <lines>
-        <chord name="A"/>Sing the wondrous love of Jesus, <chord name="E7"/>Sing His mercy and His <chord name="A"/>grace;<br/>
-        <chord name="A"/>In the mansions <chord name="D"/>bright and blessed, <chord name="A"/>He'll pre<chord name="E7"/>pare for us a <chord name="A"/>place.
+        <chord root="A"/>Sing the wondrous love of Jesus, <chord root="E" structure="dom7"/>Sing His mercy and His <chord root="A"/>grace;<br/>
+        <chord root="A"/>In the mansions <chord root="D"/>bright and blessed, <chord root="A"/>He'll pre<chord root="E" structure="dom7"/>pare for us a <chord root="A"/>place.
       </lines>
     </verse>
     <verse name="c">
       <lines>
-        When we <chord name="A"/>all get to heaven, What a day of re<chord name="B7"/>joicing that will <chord name="E7"/>be;<br/>
-        When we <chord name="A"/>all see <chord name="D"/>Jesus, We'll <chord name="A"/>sing and <chord name="E7"/>shout the victo<chord name="A"/>ry.
+        When we <chord root="A"/>all get to heaven, What a day of re<chord root="B" structure="dom7"/>joicing that will <chord root="E" structure="dom7"/>be;<br/>
+        When we <chord root="A"/>all see <chord root="D"/>Jesus, We'll <chord root="A"/>sing and <chord root="E" structure="dom7"/>shout the victo<chord root="A"/>ry.
       </lines>
     </verse>
     <verse name="v2">
       <lines>
-        <chord name="A"/>While we walk the pilgrim pathway, <chord name="E7"/>Clouds will over spread the <chord name="A"/>sky;<br/>
-        <chord name="A"/>But when travelling <chord name="D"/>days are over, <chord name="A"/>Not a <chord name="E7"/>shadow, not a <chord name="A"/>sigh.
+        <chord root="A"/>While we walk the pilgrim pathway, <chord root="E" structure="dom7"/>Clouds will over spread the <chord root="A"/>sky;<br/>
+        <chord root="A"/>But when travelling <chord root="D"/>days are over, <chord root="A"/>Not a <chord root="E" structure="dom7"/>shadow, not a <chord root="A"/>sigh.
       </lines>
     </verse>
     <verse name="v3">
       <lines>
-        <chord name="A"/>Let us then be true and faithful, <chord name="E7"/>Trusting serving every<chord name="A"/>day;<br/>
-        <chord name="A"/>Just one glimpse of <chord name="D"/>Him in glory, <chord name="A"/>Will the <chord name="E7"/>toils of life re<chord name="A"/>pay.
+        <chord root="A"/>Let us then be true and faithful, <chord root="E" structure="dom7"/>Trusting serving every<chord root="A"/>day;<br/>
+        <chord root="A"/>Just one glimpse of <chord root="D"/>Him in glory, <chord root="A"/>Will the <chord root="E" structure="dom7"/>toils of life re<chord root="A"/>pay.
       </lines>
     </verse>
     <verse name="v4">
       <lines>
-        <chord name="A"/>Onward to the prize before us, <chord name="E7"/>Soon His beauty we'll be<chord name="A"/>hold;<br/>
-        <chord name="A"/>Soon the pearly <chord name="D"/>gates will open, <chord name="A"/>We shall <chord name="E7"/>tread the streets of <chord name="A"/>gold.
+        <chord root="A"/>Onward to the prize before us, <chord root="E" structure="dom7"/>Soon His beauty we'll be<chord root="A"/>hold;<br/>
+        <chord root="A"/>Soon the pearly <chord root="D"/>gates will open, <chord root="A"/>We shall <chord root="E" structure="dom7"/>tread the streets of <chord root="A"/>gold.
       </lines>
     </verse>
   </lyrics>

--- a/stylesheets/css/openlyrics-0.9-chord.xml.css
+++ b/stylesheets/css/openlyrics-0.9-chord.xml.css
@@ -215,7 +215,7 @@ chord[structure="m3-d5-m7"],   chord[structure="halfdim7"] { --chord-structure: 
 chord[structure="m3-5-7"],     chord[structure="minmaj7"]  { --chord-structure: "mΔ" /*mMaj7*/ /*mM7*/ /*-M7*/ /*-Δ*/ /*-Δ7*/ }
 chord[structure="3-a5-7"],     chord[structure="augmaj7"]  { --chord-structure: "+Δ" /*Maj7(♯5)*/ /*+Maj7*/ /*+M7*/ /*+Δ7*/ }
 chord[structure="3-d5-m7"]                                 { --chord-structure: "7,5♭" /*7(♭5)*/ }
-chord[structure="3-a5-m7"],    chord[structure="aug7"]     { --chord-structure: "7" /*7,5♯*/ /*7(♯5)*/ }
+chord[structure="3-a5-m7"],    chord[structure="aug7"]     { --chord-structure: "+7" /*7,5♯*/ /*7(♯5)*/ }
 chord[structure="m3-d5-7"]                                 { --chord-structure: "mΔ,5♭" /*mΔ(5♭)*/ /*mMaj7(♭5)*/ /*mM7(♭5)*/ /*-Δ7(♭5)*/ }
 chord[structure="3-d5-7"]                                  { --chord-structure: "Δ,5♭" /*Δ7(♭5)*/ /*Maj7(♭5)*/ /*M7(♭5)*/ }
 chord[structure="3-5-6"],      chord[structure="maj6"]     { --chord-structure: "6" /*M6*/ /*add6*/ }
@@ -229,7 +229,7 @@ chord[structure="3-5-7-9"],    chord[structure="maj9"]     { --chord-structure: 
 chord[structure="m3-5-m7-9"],  chord[structure="min9"]     { --chord-structure: "m9" /*m7,9*/ /*-9*/ /*min9*/ }
 chord[structure="m3-5-7-9"],   chord[structure="minmaj9"]  { --chord-structure: "mΔ9" /*mMaj9*/ /*mM9*/ /*-M9*/ /*-Δ9*/ }
 chord[structure="3-a5-7-9"]                                { --chord-structure: "+Δ9" /*Maj9(♯5)*/ /*+Maj9*/ /*+M9*/ }
-chord[structure="3-a5-m7-9"],  chord[structure="aug9"]     { --chord-structure: "9" /*7,9*/ /*9,5♯*/ /*9(♯5)*/ }
+chord[structure="3-a5-m7-9"],  chord[structure="aug9"]     { --chord-structure: "+9" /*+7,9*/ /*9,5♯*/ /*9(♯5)*/ }
 chord[structure="m3-d5-m7-9"], chord[structure="halfdim9"] { --chord-structure: "ø9" /*m9,5♭*/ /*m9(♭5)*/ /*-9(♭5)*/ /*halfdim9*/ }
 chord[structure="m3-d5-m7-m9"]                             { --chord-structure: "ø9♭" /*ø(♭9)*/ /*m7,9♭,5♭*/ /*m7(♭9,♭5)*/ /*-7(♭9,♭5)*/ /*halfdim(♭9)*/ }
 chord[structure="m3-d5-d7-9"]                              { --chord-structure: "°9" /*dim9*/ }
@@ -245,7 +245,7 @@ chord[structure="3-5-7-9-a11"]                             { --chord-structure: 
 chord[structure="m3-5-m7-9-a11"]                           { --chord-structure: "m11♯" /*m(♯11)*/ /*-(♯11)*/ /*min(♯11)*/ }
 chord[structure="m3-5-7-9-a11"]                            { --chord-structure: "mΔ11♯" /*mΔ(♯11)*/ /*mMaj(♯11)*/ /*mM(♯11)*/ /*-M(♯11)*/ /*-Δ(♯11)*/ }
 chord[structure="3-a5-7-9-11"]                             { --chord-structure: "+Δ11" /*Maj11(♯5)*/ /*+Maj11*/ /*+M11*/ }
-chord[structure="3-a5-m7-9-11"]                            { --chord-structure: "11" /*11,5♯*/ /*11(♯5)*/ }
+chord[structure="3-a5-m7-9-11"]                            { --chord-structure: "+11" /*11,5♯*/ /*11(♯5)*/ }
 chord[structure="m3-d5-m7-m9-11"]                          { --chord-structure: "ø11" /*m11,5♭*/ /*m11(♭5)*/ /*-11(♭5)*/ /*halfdim11*/ }
 chord[structure="m3-d5-d7-m9-d11"]                         { --chord-structure: "°11" /*dim11*/ }
 /* 7 note chords */
@@ -258,7 +258,7 @@ chord[structure="3-5-7-9-a11-13"]                          { --chord-structure: 
 chord[structure="m3-5-m7-9-a11-13"]                        { --chord-structure: "m13(♯11)" /*-13(♯11)*/ /*min13(♯11)*/ }
 chord[structure="m3-5-7-9-a11-13"]                         { --chord-structure: "mΔ13(♯11)" /*mMaj13(♯11)*/ /*mM13(♯11)*/ /*-M13(♯11)*/ /*-Δ13(♯11)*/ }
 chord[structure="3-a5-7-9-11-13"]                          { --chord-structure: "+Δ13" /*Maj13(♯5)*/ /*+Maj13*/ /*+M13*/ }
-chord[structure="3-a5-m7-9-11-13"]                         { --chord-structure: "13" /*13,5♯*/ /*13(♯5)*/ }
+chord[structure="3-a5-m7-9-11-13"]                         { --chord-structure: "+13" /*13,5♯*/ /*13(♯5)*/ }
 chord[structure="m3-d5-m7-m9-11-13"]                       { --chord-structure: "ø13" /*m13,5♭*/ /*m13(♭5)*/ /*-13(♭5)*/ /*halfdim13*/ }
 /* Figured 3 note chords */
 chord[structure="4-5"],        chord[structure="sus4"]     { --chord-structure: "4" /*sus4*/ /*sus*/ }
@@ -276,7 +276,7 @@ chord[structure="4-5-m7-9"]                                { --chord-structure: 
 chord[structure="4-5-m7-m9"]                               { --chord-structure: "7,9♭,4" /*7(♭9)*/ /*7,9♭,sus4*/ /*7(♭9)sus4*/ }
 chord[structure="4-5-7-9"]                                 { --chord-structure: "Δ9,4" /*Δ9sus4*/ /*Maj9,4*/ /*M9,4*/ /*Maj9sus4*/ /*M9sus4*/ }
 chord[structure="4-a5-7-9"]                                { --chord-structure: "+Δ9,4" /*+Δ9sus4*/ /*Maj9(♯5)4*/ /*+M9,4*/ /*+M9sus4*/ /*+Maj9,4*/ }
-chord[structure="4-a5-m7-9"]                               { --chord-structure: "9,4" /*+9sus4*/ /*9(♯5)sus4*/ }
+chord[structure="4-a5-m7-9"]                               { --chord-structure: "+9,4" /*+9sus4*/ /*9(♯5)sus4*/ }
 
 
 /*

--- a/stylesheets/xsl/openlyrics-0.9-chord.xml
+++ b/stylesheets/xsl/openlyrics-0.9-chord.xml
@@ -112,7 +112,7 @@
   <structure id="m3-5-7" shorthand="minmaj7">mΔ</structure><!-- mMaj7 --><!-- mM7 --><!-- -M7 --><!-- -Δ --><!-- -Δ7 -->
   <structure id="3-a5-7" shorthand="augmaj7">+Δ</structure><!-- Maj7(♯5) --><!-- +Maj7 --><!-- +M7 --><!-- +Δ7 -->
   <structure id="3-d5-m7">7,5♭</structure><!-- 7(♭5) -->
-  <structure id="3-a5-m7" shorthand="aug7">7</structure><!-- 7,5♯ --><!-- 7(♯5) -->
+  <structure id="3-a5-m7" shorthand="aug7">+7</structure><!-- 7,5♯ --><!-- 7(♯5) -->
   <structure id="m3-d5-7">mΔ,5♭</structure><!-- mΔ(5♭) --><!-- mMaj7(♭5) --><!-- mM7(♭5) --><!-- -Δ7(♭5) -->
   <structure id="3-d5-7">Δ,5♭</structure><!-- Δ7(♭5) --><!-- Maj7(♭5) --><!-- M7(♭5) -->
   <structure id="3-5-6" shorthand="maj6">6</structure><!-- M6 --><!-- add6 -->
@@ -126,7 +126,7 @@
   <structure id="m3-5-m7-9" shorthand="min9">m9</structure><!-- m7,9 --><!-- -9 --><!-- min9 -->
   <structure id="m3-5-7-9" shorthand="minmaj9">mΔ9</structure><!-- mMaj9 --><!-- mM9 --><!-- -M9 --><!-- -Δ9 -->
   <structure id="3-a5-7-9">+Δ9</structure><!-- Maj9(♯5) --><!-- +Maj9 --><!-- +M9 -->
-  <structure id="3-a5-m7-9" shorthand="aug9">9</structure><!-- 7,9 --><!-- 9,5♯ --><!-- 9(♯5) -->
+  <structure id="3-a5-m7-9" shorthand="aug9">+9</structure><!-- +7,9 --><!-- 9,5♯ --><!-- 9(♯5) -->
   <structure id="m3-d5-m7-9" shorthand="halfdim9">ø9</structure><!-- m9,5♭ --><!-- m9(♭5) --><!-- -9(♭5) --><!-- halfdim9 -->
   <structure id="m3-d5-m7-m9">ø9♭</structure><!-- ø(♭9) --><!-- m7,9♭,5♭ --><!-- m7(♭9,♭5) --><!-- -7(♭9,♭5) --><!-- halfdim(♭9) -->
   <structure id="m3-d5-d7-9">°9</structure><!-- dim9 -->
@@ -142,7 +142,7 @@
   <structure id="m3-5-m7-9-a11">m11♯</structure><!-- m(♯11) --><!-- -(♯11) --><!-- min(♯11) -->
   <structure id="m3-5-7-9-a11">mΔ11♯</structure><!-- mΔ(♯11) --><!-- mMaj(♯11) --><!-- mM(♯11) --><!-- -M(♯11) --><!-- -Δ(♯11) -->
   <structure id="3-a5-7-9-11">+Δ11</structure><!-- Maj11(♯5) --><!-- +Maj11 --><!-- +M11 -->
-  <structure id="3-a5-m7-9-11">11</structure><!-- 11,5♯ --><!-- 11(♯5) -->
+  <structure id="3-a5-m7-9-11">+11</structure><!-- 11,5♯ --><!-- 11(♯5) -->
   <structure id="m3-d5-m7-m9-11">ø11</structure><!-- m11,5♭ --><!-- m11(♭5) --><!-- -11(♭5) --><!-- halfdim11 -->
   <structure id="m3-d5-d7-m9-d11">°11</structure><!-- dim11 -->
   <!-- 7 note chords -->
@@ -155,7 +155,7 @@
   <structure id="m3-5-m7-9-a11-13">m13(♯11)</structure><!-- -13(♯11) --><!-- min13(♯11) -->
   <structure id="m3-5-7-9-a11-13">mΔ13(♯11)</structure><!-- mMaj13(♯11) --><!-- mM13(♯11) --><!-- -M13(♯11) --><!-- -Δ13(♯11) -->
   <structure id="3-a5-7-9-11-13">+Δ13</structure><!-- Maj13(♯5) --><!-- +Maj13 --><!-- +M13 -->
-  <structure id="3-a5-m7-9-11-13">13</structure><!-- 13,5♯ --><!-- 13(♯5) -->
+  <structure id="3-a5-m7-9-11-13">+13</structure><!-- 13,5♯ --><!-- 13(♯5) -->
   <structure id="m3-d5-m7-m9-11-13">ø13</structure><!-- m13,5♭ --><!-- m13(♭5) --><!-- -13(♭5) --><!-- halfdim13 -->
   <!-- Figured 3 note chords -->
   <structure id="4-5" shorthand="sus4">4</structure><!-- sus4 --><!-- sus -->
@@ -173,6 +173,6 @@
   <structure id="4-5-m7-m9">7,9♭,4</structure><!-- 7(♭9) --><!-- 7,9♭,sus4 --><!-- 7(♭9)sus4 -->
   <structure id="4-5-7-9">Δ9,4</structure><!-- Δ9sus4 --><!-- Maj9,4 --><!-- M9,4 --><!-- Maj9sus4 --><!-- M9sus4 -->
   <structure id="4-a5-7-9">+Δ9,4</structure><!-- +Δ9sus4 --><!-- Maj9(♯5)4 --><!-- +M9,4 --><!-- +M9sus4 --><!-- +Maj9,4 -->
-  <structure id="4-a5-m7-9">9,4</structure><!-- +9sus4 --><!-- 9(♯5)sus4 -->
+  <structure id="4-a5-m7-9">+9,4</structure><!-- +9sus4 --><!-- 9(♯5)sus4 -->
 
 </chordNotation>

--- a/tools/openlyrics-0.8-to-openlyrics-0.9.xsl
+++ b/tools/openlyrics-0.8-to-openlyrics-0.9.xsl
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet
+ version="1.0"
+ xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+ xmlns:ol="http://openlyrics.info/namespace/2009/song"
+ xmlns:str="http://exslt.org/strings"
+ extension-element-prefixes="str"
+ xmlns="http://openlyrics.info/namespace/2009/song">
+  <xsl:output method="xml" encoding="utf-8" indent="yes"/>
+
+  <!-- Main: copy all nodes and attributes -->
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Set OL version -->
+  <xsl:template match="/ol:song/@version">
+    <xsl:attribute name="version">0.9</xsl:attribute>
+  </xsl:template>
+
+  <!-- Convert chords -->
+  <xsl:template match="//ol:chord">
+    <!-- Tokenize @name to $root, $structure, $bass
+         If regexp:match worked... ^([ABE]b|[ACDFG]#|[ABCDEFG])([\d\w\(\)\+\#]*)?(?:\/([ABE]b|[ACDFG]#|[ABCDEFG]))?$
+         Supports all variation of https://github.com/openlyrics/openlyrics/blob/v0.8/chords.txt
+         - Root/Bass: C, C#, Db, D, D#, Eb, E, F, F#, Gb, G, G#, Ab, A, A#, Bb, B.
+           Any other input will return 'UNKNOWN:' frefix.
+         - Structure: 5, maj, m, +, dim, 7, maj7, m7, 7(b5), m7b5, maj7(#5), 6, m6, 9, 7(b9), 7b9, maj9, m9, 11, m11, 13,
+           4, sus, sus4, sus2, sus9, (add9), (addD), addD, add2, add9, addG7(sus4), 7sus4, 7sus2, maj7sus4, 9sus
+    -->
+    <xsl:variable name="temp">
+      <xsl:choose>
+        <xsl:when test="contains(@name, '/')">
+          <xsl:value-of select="substring-before(@name, '/' )" />
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="@name" />
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+    <xsl:variable name="bass" select="substring-after(@name, concat($temp, '/'))" />
+    <xsl:variable name="root">
+      <xsl:choose>
+        <xsl:when test="substring($temp, 2, 1) = '#' or substring($temp, 2, 1) = 'b'">
+          <xsl:value-of select="substring($temp, 1, 2)" />
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="substring($temp, 1, 1)" />
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+    <xsl:variable name="structure" select="substring-after($temp, $root )"/>
+    <!-- Convert to new attributes -->
+    <xsl:element name="{local-name()}" namespace="{namespace-uri(}">
+      <xsl:attribute name="root">
+        <xsl:call-template name="convertNote">
+          <xsl:with-param name="note" select="$root"/>
+        </xsl:call-template>
+      </xsl:attribute>
+      <xsl:if test="$structure != ''">
+        <xsl:attribute name="structure">
+          <xsl:choose>
+            <xsl:when test="$structure = 'm'">min</xsl:when>
+            <xsl:when test="$structure = '5'">power</xsl:when>
+            <xsl:when test="$structure = 'maj'"></xsl:when>
+            <xsl:when test="$structure = 'm'">min</xsl:when>
+            <xsl:when test="$structure = '+'">aug</xsl:when>
+            <xsl:when test="$structure = 'dim'">dim</xsl:when>
+            <xsl:when test="$structure = '7'">dom7</xsl:when>
+            <xsl:when test="$structure = 'maj7'">maj7</xsl:when>
+            <xsl:when test="$structure = 'm7'">min7</xsl:when>
+            <xsl:when test="$structure = '7(b5)' or $structure = 'm7b5'">halfdim7</xsl:when>
+            <xsl:when test="$structure = 'maj7(#5)'">augmaj7</xsl:when>
+            <xsl:when test="$structure = '6'">maj6</xsl:when>
+            <xsl:when test="$structure = 'm6'">min6</xsl:when>
+            <xsl:when test="$structure = '9'">dom9</xsl:when>
+            <xsl:when test="$structure = '7(b9)' or $structure = '7b9'">dom9b</xsl:when>
+            <xsl:when test="$structure = 'maj9'">maj9</xsl:when>
+            <xsl:when test="$structure = 'm9'">min9</xsl:when>
+            <xsl:when test="$structure = '11'">3-5-m7-9-11</xsl:when>
+            <xsl:when test="$structure = 'm11'">m3-5-m7-9-11</xsl:when>
+            <xsl:when test="$structure = '13'">3-5-m7-9-11-13</xsl:when>
+            <xsl:when test="$structure = '4'or $structure = 'sus' or $structure = 'sus4'">sus4</xsl:when>
+            <xsl:when test="$structure = 'sus2' or $structure = 'sus9'">sus2</xsl:when>
+            <xsl:when test="$structure = '(add9)' or $structure = '(addD)' or $structure = 'addD' or $structure = 'add2' or $structure = 'add9' or $structure = 'addG'">add9</xsl:when>
+            <xsl:when test="$structure = '7(sus4)' or $structure = '7sus4'">4-5-m7</xsl:when>
+            <xsl:when test="$structure = '7sus2'">2-5-m7</xsl:when>
+            <xsl:when test="$structure = 'maj7sus4'">4-5-7</xsl:when>
+            <xsl:when test="$structure = '9sus'">4-5-m7-9</xsl:when>
+            <xsl:otherwise>UNKNOWN:<xsl:value-of select="$structure"/></xsl:otherwise>
+          </xsl:choose>
+        </xsl:attribute>
+      </xsl:if>
+      <xsl:if test="$bass != ''">
+        <xsl:attribute name="bass">
+          <xsl:call-template name="convertNote">
+            <xsl:with-param name="note" select="$bass"/>
+          </xsl:call-template>
+        </xsl:attribute>
+      </xsl:if>
+    </xsl:element>
+  </xsl:template>
+
+  <xsl:template name="convertNote">
+    <xsl:param name="note" />
+    <xsl:choose>
+      <xsl:when test="$note = 'C'  or
+                      $note = 'C#' or
+                      $note = 'Db' or
+                      $note = 'D'  or
+                      $note = 'D#' or
+                      $note = 'Eb' or
+                      $note = 'E'  or
+                      $note = 'F'  or
+                      $note = 'F#' or
+                      $note = 'Gb' or
+                      $note = 'G'  or
+                      $note = 'G#' or
+                      $note = 'Ab' or
+                      $note = 'A'  or
+                      $note = 'A#' or
+                      $note = 'Bb' or
+                      $note = 'B'">
+        <xsl:value-of select="$note"/>
+      </xsl:when>
+      <xsl:otherwise>UNKNOWN:<xsl:value-of select="$note"/></xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/tools/openlyrics-0.8-to-openlyrics-0.9.xsl
+++ b/tools/openlyrics-0.8-to-openlyrics-0.9.xsl
@@ -72,6 +72,7 @@
             <xsl:when test="$structure = 'maj7'">maj7</xsl:when>
             <xsl:when test="$structure = 'm7'">min7</xsl:when>
             <xsl:when test="$structure = '7(b5)' or $structure = 'm7b5'">halfdim7</xsl:when>
+            <xsl:when test="$structure = 'm#7' or $structure = 'm(#7)' or $structure = 'm(maj7)' or $structure = 'mmaj7'">minmaj7</xsl:when>
             <xsl:when test="$structure = 'maj7(#5)'">augmaj7</xsl:when>
             <xsl:when test="$structure = '6'">maj6</xsl:when>
             <xsl:when test="$structure = 'm6'">min6</xsl:when>
@@ -79,13 +80,15 @@
             <xsl:when test="$structure = '7(b9)' or $structure = '7b9'">dom9b</xsl:when>
             <xsl:when test="$structure = 'maj9'">maj9</xsl:when>
             <xsl:when test="$structure = 'm9'">min9</xsl:when>
+            <xsl:when test="$structure = 'm9(maj7)' or $structure = 'm9maj7'">minmaj9</xsl:when>
+            <xsl:when test="$structure = '7#9' or $structure = '7(#9)'">3-5-m7-m10</xsl:when>
             <xsl:when test="$structure = '11'">3-5-m7-9-11</xsl:when>
             <xsl:when test="$structure = 'm11'">m3-5-m7-9-11</xsl:when>
             <xsl:when test="$structure = '13'">3-5-m7-9-11-13</xsl:when>
-            <xsl:when test="$structure = '4'or $structure = 'sus' or $structure = 'sus4'">sus4</xsl:when>
-            <xsl:when test="$structure = 'sus2' or $structure = 'sus9'">sus2</xsl:when>
-            <xsl:when test="$structure = '(add9)' or $structure = '(addD)' or $structure = 'addD' or $structure = 'add2' or $structure = 'add9' or $structure = 'addG'">add9</xsl:when>
-            <xsl:when test="$structure = '7(sus4)' or $structure = '7sus4'">4-5-m7</xsl:when>
+            <xsl:when test="$structure = '4'or $structure = 'sus' or $structure = 'sus4' or $structure ='m(sus4)' or $structure = 'msus4'">sus4</xsl:when>
+            <xsl:when test="$structure = 'sus2' or $structure = 'sus9' or $structure='m(sus9)' or $structure = 'msus9'">sus2</xsl:when>
+            <xsl:when test="$structure = '2' or $structure = '(add9)' or $structure = '(addD)' or $structure = 'addD' or $structure = 'add2' or $structure = 'add9' or $structure = 'addG'">add9</xsl:when>
+            <xsl:when test="$structure = '7(sus4)' or $structure = '7sus4' or $structure = 'addE'">4-5-m7</xsl:when>
             <xsl:when test="$structure = '7sus2'">2-5-m7</xsl:when>
             <xsl:when test="$structure = 'maj7sus4'">4-5-7</xsl:when>
             <xsl:when test="$structure = '9sus'">4-5-m7-9</xsl:when>


### PR DESCRIPTION
@matysek, please review. This time it's a much smaller package.

1. Martin, here is the discussed XSL converter from OpenLyrics 0.8 to 0.9:
- Converts `<chord>` tag and its attributes. It supports the set defined in https://github.com/openlyrics/openlyrics/blob/v0.8/chords.txt. I plan to extend this set later.
- Sets the `version` to "0.9".

2. I converted with this method all examples in `/songs` directory.

3. I found a mistake what I made: I changed previously (230f76f) the `verseNameType` from `NMTOKEN` to `ID` because the manual sasy it is unique. But... When I made this conversion I found an opposite example: Hava Nagila.xml. If there is a transliteration or translation we use this structure:
```xml
<verse name="v1" lang="he"></verse>
<verse name="v1" lang="he" translit="en"></verse>
<verse name="v1" lang="en"></verse>
```
So I revoke my modification in this pull request. Please review this part as well.

`/docs/source/dataformat.rst` says: "They should be unique, written in lower case, a single word..." Maybe we should explain this better or clearly. What do you mean?

4. I made some other trivial fixes. See commits.

